### PR TITLE
secp256k1 key generation, signing, and verification

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,8 @@ let package = Package(
             name: "tbDEXTests",
             dependencies: ["tbDEX"],
             resources: [
-                .copy("TestVectors/ed25519")
+                .copy("TestVectors/ed25519"),
+                .copy("TestVectors/secp256k1")
             ]
         ),
     ]

--- a/Sources/tbDEX/crypto/Secp256k1.swift
+++ b/Sources/tbDEX/crypto/Secp256k1.swift
@@ -1,0 +1,268 @@
+import Foundation
+import secp256k1
+
+public enum Secp256k1 {
+
+    // MARK: - Constants
+
+    /// Uncompressed key leading byte that indicates both the X and Y coordinates are available directly within the key.
+    static let uncompressedKeyID: UInt8 = 0x04
+
+    /// Compressed key leading byte that indicates the Y coordinate is even.
+    static let compressedKeyEvenYID: UInt8 = 0x02
+
+    /// Compressed key leading byte that indicates the Y coordinate is odd.
+    static let compressedKeyOddYID: UInt8 = 0x03
+
+    /// Size of an uncompressed public key, in bytes.
+    ///
+    /// An uncompressed key is represented with a leading 0x04 bytes,
+    /// followed by 32 bytes for the x-coordinate and 32 bytes for the y-coordinate.
+    static let uncompressedKeySize: Int = 65
+
+    /// Size of a compressed public key, in bytes.
+    ///
+    /// A compressed key is represented with a leading 0x02 or 0x03 byte,
+    /// followed by 32 bytes for the x-coordinate.
+    static let compressedKeySize: Int = 33
+
+    /// Size of a private key, in bytes.
+    static let privateKeySize: Int = 32
+
+    // MARK: - Public Functions
+
+    /// Generates an Secp256k1 private key in JSON Web Key (JWK) format.
+    public static func generatePrivateKey() throws -> Jwk {
+        return try generatePrivateJwk(
+            privateKey:secp256k1.Signing.PrivateKey()
+        )
+    }
+
+    /// Derives the public key in JSON Web Key (JWK) format from a given Secp256k1 private key in JWK format.
+    public static func computePublicKey(privateKey: Jwk) throws -> Jwk {
+        guard let d = privateKey.d else {
+            throw Secpsecp256k1Error.invalidPrivateJwk
+        }
+
+        let privateKeyData = try d.decodeBase64Url()
+        let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: privateKeyData)
+
+        return try generatePublicJwk(publicKey: privateKey.publicKey)
+    }
+
+    /// Converts raw Secp256k1 private key in bytes to its corresponding JSON Web Key (JWK) format.
+    public static func bytesToPrivateKey(_ bytes: Data) throws -> Jwk {
+        let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: bytes)
+        return try generatePrivateJwk(privateKey: privateKey)
+    }
+
+
+    /// Converts a raw Secp256k1 public key in bytes to its corresponding JSON Web Key (JWK) format.
+    public static func bytesToPublicKey(_ bytes: Data) throws -> Jwk {
+        let publicKey = try secp256k1.Signing.PublicKey(
+            dataRepresentation: bytes,
+            format: bytes.isCompressed() ? .compressed : .uncompressed
+        )
+
+        return try generatePublicJwk(publicKey: publicKey)
+    }
+
+    /// Converts a Secp256k1 private key from JSON Web Key (JWK) format to a raw bytes.
+    public static func privateKeyToBytes(_ privateKey: Jwk) throws -> Data {
+        guard let d = privateKey.d else {
+            throw Secpsecp256k1Error.invalidPrivateJwk
+        }
+
+        return try d.decodeBase64Url()
+    }
+
+    /// Converts a Secp256k1 public key from JSON Web Key (JWK) format to a raw bytes.
+    public static func publicKeyToBytes(_ publicKey: Jwk) throws -> Data {
+        guard let x = publicKey.x,
+              let y = publicKey.y
+        else {
+            throw Secpsecp256k1Error.invalidPublicJwk
+        }
+
+        var data = Data()
+        data.append(Self.uncompressedKeyID)
+        data.append(contentsOf: try x.decodeBase64Url())
+        data.append(contentsOf: try y.decodeBase64Url())
+
+        guard data.count == Self.uncompressedKeySize else {
+            throw Secpsecp256k1Error.internalError(reason: "Public Key incorrect size: \(data.count)")
+        }
+
+        return data
+    }
+
+    /// Converts a Secp256k1 raw public key to its compressed form.
+    public static func compressPublicKey(publicKeyBytes: Data) throws -> Data {
+        guard publicKeyBytes.count == Self.uncompressedKeySize,
+              publicKeyBytes.first == Self.uncompressedKeyID
+        else {
+            throw Secpsecp256k1Error.internalError(reason: "Public key must be 65 bytes long an start with 0x04")
+        }
+
+        let xBytes = publicKeyBytes[1...32]
+        let yBytes = publicKeyBytes[33...64]
+
+        let prefix = if yBytes.last! % 2 == 0 {
+            Self.compressedKeyEvenYID
+        } else {
+            Self.compressedKeyOddYID
+        }
+
+        var data = Data()
+        data.append(prefix)
+        data.append(contentsOf: xBytes)
+        return data
+    }
+
+    /// Converts a Secp256k1 raw public key to its uncompressed form.
+    public static func decompressPublicKey(publicKeyBytes: Data) throws -> Data {
+        let format: secp256k1.Format = publicKeyBytes.count == Self.compressedKeySize ? .compressed : .uncompressed
+        let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyBytes, format: format)
+        return publicKey.uncompressedBytes()
+    }
+
+    /// Generates an RFC6979-compliant ECDSA signature of given data using a Secp256k1 private key in JSON Web Key
+    /// (JWK) format.
+    public static func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol {
+        guard let d = privateKey.d else {
+            throw Secpsecp256k1Error.invalidPrivateJwk
+        }
+
+        let privateKeyData = try d.decodeBase64Url()
+        let privateKey = try secp256k1.Signing.PrivateKey(
+            dataRepresentation: privateKeyData,
+            format: privateKeyData.isCompressed() ? .compressed : .uncompressed
+        )
+        return try privateKey.signature(for: payload).dataRepresentation
+    }
+
+    /// Verifies an RFC6979-compliant ECDSA signature against given data and a Secp256k1 public key in JSON Web Key
+    /// (JWK) format.
+    public static func verify<S,D>(publicKey: Jwk, signature: S, signedPayload: D) throws -> Bool where S: DataProtocol, D: DataProtocol {
+        let publicKeyBytes = try publicKeyToBytes(publicKey)
+        let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyBytes, format: .uncompressed)
+
+        let ecdsaSignature = try secp256k1.Signing.ECDSASignature(dataRepresentation: signature)
+        return publicKey.isValidSignature(ecdsaSignature, for: signedPayload)
+    }
+
+    // MARK: - Internal Functions
+
+    /// Computes the elliptic curve points (x and y coordinates) for a given a raw Secp256k1 key
+    static func getCurvePoints(keyBytes: Data) throws -> (Data, Data) {
+        var keyBytes = keyBytes
+
+        // If provided key bytes represent a private key, first compute the public key
+        if keyBytes.count == Self.privateKeySize {
+            let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: keyBytes)
+            let publicKey = privateKey.publicKey
+            keyBytes = publicKey.dataRepresentation
+        }
+
+        let uncompresssedBytes = try Self.decompressPublicKey(publicKeyBytes: keyBytes)
+        let x = uncompresssedBytes[1...32]
+        let y = uncompresssedBytes[33...64]
+
+        return (x, y)
+    }
+
+    /// Validates a given raw Secp256k1 private key to ensure its compliance with the secp256k1 curve standards.
+    static func validatePrivateKey(privateKeyBytes: Data) -> Bool {
+        do {
+            let _ = try secp256k1.Signing.PrivateKey(dataRepresentation: privateKeyBytes)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    /// Validates a given raw Secp256k1 public key to confirm its mathematical correctness on the secp256k1 curve.
+    static func validatePublicKey(publicKeyBytes: Data) -> Bool {
+        do {
+            let format: secp256k1.Format = publicKeyBytes.count == Self.compressedKeySize ? .compressed : .uncompressed
+            let _ = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyBytes, format: format)
+            return true
+        } catch {
+            return false
+        }
+    }
+
+    // MARK: - Private Functions
+
+    private static func generatePrivateJwk(privateKey: secp256k1.Signing.PrivateKey) throws -> Jwk {
+        let (x, y) = try getCurvePoints(keyBytes: privateKey.dataRepresentation)
+
+        var jwk = Jwk(
+            keyType: .elliptic,
+            curve: .secp256k1,
+            d: privateKey.dataRepresentation.base64UrlEncodedString(),
+            x: x.base64UrlEncodedString(),
+            y: y.base64UrlEncodedString()
+        )
+
+        jwk.keyIdentifier = try jwk.thumbprint()
+
+        return jwk
+    }
+
+    private static func generatePublicJwk(publicKey: secp256k1.Signing.PublicKey) throws -> Jwk {
+        let (x, y) = try getCurvePoints(keyBytes: publicKey.dataRepresentation)
+
+        var jwk = Jwk(
+            keyType: .elliptic,
+            curve: .secp256k1,
+            x: x.base64UrlEncodedString(),
+            y: y.base64UrlEncodedString()
+        )
+
+        jwk.keyIdentifier = try jwk.thumbprint()
+
+        return jwk
+    }
+}
+
+public enum Secpsecp256k1Error: Error {
+    /// The private Jwk provide did not have the appropriate parameters set on it
+    case invalidPrivateJwk
+    /// The public Jwk provide did not have the appropriate parameters set on it
+    case invalidPublicJwk
+    /// Something internally went wrong, check `reason` for more information about the exact error
+    case internalError(reason: String)
+}
+
+// MARK: - Helper extensions
+
+private extension Data {
+    func isCompressed() -> Bool {
+        return self.count == Secp256k1.compressedKeySize
+    }
+}
+
+private extension secp256k1.Signing.PublicKey {
+
+    /// Get the uncompressed bytes for a given public key.
+    ///
+    /// With a compressed public key, there's no direct access to the y-coordinate for use within
+    /// a Jwk. To avoid doing manual computations along the curve to compute the y-coordinate, this
+    /// function offloads the work to the `secp256k1` library to compute it for us.
+    func uncompressedBytes() -> Data {
+        switch self.format {
+        case .uncompressed:
+            return self.dataRepresentation
+        case .compressed:
+            let targetFormat = secp256k1.Format.uncompressed
+            var keyLength = targetFormat.length
+            var key = self.rawRepresentation
+
+            let context = secp256k1.Context.rawRepresentation
+            var bytes = [UInt8](repeating: 0, count: keyLength)
+            secp256k1_ec_pubkey_serialize(context, &bytes, &keyLength, &key, targetFormat.rawValue)
+            return Data(bytes)
+        }
+    }
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/bytes-to-private-key.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/bytes-to-private-key.json
@@ -1,0 +1,61 @@
+{
+  "description" : "Secp256k1 bytesToPrivateKey test vectors",
+  "vectors"     : [
+    {
+      "description" : "converts noble ecdsa vector 1 to the expected private key",
+      "input"       : {
+        "privateKeyBytes": "0000000000000000000000000000000000000000000000000000000000000001"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "d" : "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+        "kid" : "2JF8vg9etJzjFwZwmkvhBLLZ0bfMVVOPivYR5lFtcec",
+        "kty" : "EC",
+        "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg"
+      }
+    },
+    {
+      "description" : "converts noble ecdsa vector 2 to the expected private key",
+      "input"       : {
+        "privateKeyBytes": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "d" : "_____________________rqu3OavSKA7v9JejNA2QUA",
+        "kid" : "A5kvmZN8g_rnvmmIfgTaV8S8KUnA6plB3cCmCMUZPyQ",
+        "kty" : "EC",
+        "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c"
+      }
+    },
+    {
+      "description" : "converts noble ecdsa vector 3 to the expected private key",
+      "input"       : {
+        "privateKeyBytes": "00000000000000000000000000007246174ab1e92e9149c6e446fe194d072637"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "d" : "AAAAAAAAAAAAAAAAAAByRhdKsekukUnG5Eb-GU0HJjc",
+        "kid" : "IJxfsScP6p4G8L9Yf8mYI8WIS87ulINKi0oUbS670KQ",
+        "kty" : "EC",
+        "x" : "tILZZWpOmaFc_atei0h8sHIG3xy4OvsHbG97qJCkNoE",
+        "y": "g-vgQCnVwDMAxAHbZapqnb1Hm05gvdGQoZzltVMgE9I"
+      }
+    },
+    {
+      "description" : "converts private key bytes to the expected private key JWK",
+      "input"       : {
+        "privateKeyBytes": "bb42227e72b0f2607c7810a814b6796da369e9dc22b85b739e0eb924b770cd51"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "d" : "u0IifnKw8mB8eBCoFLZ5baNp6dwiuFtzng65JLdwzVE",
+        "kid" : "ikH9Jgh0U90gMJQ1txhlaST6VOdP_ygPJNN0JPaAwTI",
+        "kty" : "EC",
+        "x" : "9zVCTdMxpNyy3W1l0VfLdkpQyFdkXvDA0Jpx3TTn1og",
+        "y": "lNsXBQzhcrrGrf9XZYri_LLN1Bye4PdfTaoHbC6PIGI"
+      }
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/bytes-to-public-key.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/bytes-to-public-key.json
@@ -1,0 +1,57 @@
+{
+  "description" : "Secp256k1 bytesToPublicKey test vectors",
+  "vectors"     : [
+    {
+      "description" : "converts wycheproof vector 1 to the expected public key",
+      "input"       : {
+        "publicKeyBytes": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "kid" : "2JF8vg9etJzjFwZwmkvhBLLZ0bfMVVOPivYR5lFtcec",
+        "kty" : "EC",
+        "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg"
+      }
+    },
+    {
+      "description" : "converts wycheproof vector 2 to the expected public key",
+      "input"       : {
+        "publicKeyBytes": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "kid" : "A5kvmZN8g_rnvmmIfgTaV8S8KUnA6plB3cCmCMUZPyQ",
+        "kty" : "EC",
+        "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+        "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c"
+      }
+    },
+    {
+      "description" : "converts wycheproof vector 3 to the expected public key",
+      "input"       : {
+        "publicKeyBytes": "04b482d9656a4e99a15cfdab5e8b487cb07206df1cb83afb076c6f7ba890a4368183ebe04029d5c03300c401db65aa6a9dbd479b4e60bdd190a19ce5b5532013d2"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "kid" : "IJxfsScP6p4G8L9Yf8mYI8WIS87ulINKi0oUbS670KQ",
+        "kty" : "EC",
+        "x" : "tILZZWpOmaFc_atei0h8sHIG3xy4OvsHbG97qJCkNoE",
+        "y": "g-vgQCnVwDMAxAHbZapqnb1Hm05gvdGQoZzltVMgE9I"
+      }
+    },
+    {
+      "description" : "converts public key bytes to the expected public key JWK",
+      "input"       : {
+        "publicKeyBytes": "04f735424dd331a4dcb2dd6d65d157cb764a50c857645ef0c0d09a71dd34e7d68894db17050ce172bac6adff57658ae2fcb2cdd41c9ee0f75f4daa076c2e8f2062"
+      },
+      "output": {
+        "crv" : "secp256k1",
+        "kid" : "ikH9Jgh0U90gMJQ1txhlaST6VOdP_ygPJNN0JPaAwTI",
+        "kty" : "EC",
+        "x" : "9zVCTdMxpNyy3W1l0VfLdkpQyFdkXvDA0Jpx3TTn1og",
+        "y": "lNsXBQzhcrrGrf9XZYri_LLN1Bye4PdfTaoHbC6PIGI"
+      }
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/get-curve-points.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/get-curve-points.json
@@ -1,0 +1,45 @@
+{
+  "description" : "Secp256k1 getCurvePoints test vectors",
+  "vectors"     : [
+    {
+      "description" : "returns public key x and y coordinates given a public key",
+      "input"       : {
+        "key": "043752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"
+      },
+      "output": {
+        "x": "3752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258",
+        "y": "c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"
+      }
+    },
+    {
+      "description" : "returns public key x and y coordinates given a private key",
+      "input"       : {
+        "key": "740ec69810de9ad1b8f298f1d2c0e6a52dd1e958dc2afc85764bec169c222e88"
+      },
+      "output": {
+        "x": "3752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258",
+        "y": "c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"
+      }
+    },
+    {
+      "description" : "handles private keys that require padded x-coordinate when converting from BigInt to bytes",
+      "input"       : {
+        "key": "0206a1f9628c5bcd31f3bbc2f160ec98f99960147e04ea192f56c53a0086c5432d"
+      },
+      "output": {
+        "x": "06a1f9628c5bcd31f3bbc2f160ec98f99960147e04ea192f56c53a0086c5432d",
+        "y": "bf2efab7943be51219a283c0979ccba0fbe03f571e75b0eb338cc2ec01e70552"
+      }
+    },
+    {
+      "description" : "handles private keys that require padded y-coordinate when converting from BigInt to bytes",
+      "input"       : {
+        "key": "032ff752fb8fc6af85c8682b0ca9d48901b2b9ac130f558bd1a9092240d42c4682"
+      },
+      "output": {
+        "x": "2ff752fb8fc6af85c8682b0ca9d48901b2b9ac130f558bd1a9092240d42c4682",
+        "y": "048c39d9ebdc1fd98bda38b7f00b93de1d2af5bb3ba8cb532ad47c1f36e19501"
+      }
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/private-key-to-bytes.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/private-key-to-bytes.json
@@ -1,0 +1,61 @@
+{
+  "description" : "Secp256k1 privateKeyToBytes test vectors",
+  "vectors"     : [
+    {
+      "description" : "converts noble ecdsa vector 1 to the expected byte array",
+      "input"       : {
+        "privateKey": {
+          "crv" : "secp256k1",
+          "d" : "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAE",
+          "kid" : "2JF8vg9etJzjFwZwmkvhBLLZ0bfMVVOPivYR5lFtcec",
+          "kty" : "EC",
+          "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+          "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg"
+        }
+      },
+      "output": "0000000000000000000000000000000000000000000000000000000000000001"
+    },
+    {
+      "description" : "converts noble ecdsa vector 2 to the expected byte array",
+      "input"       : {
+        "privateKey": {
+          "crv" : "secp256k1",
+          "d" : "_____________________rqu3OavSKA7v9JejNA2QUA",
+          "kid" : "A5kvmZN8g_rnvmmIfgTaV8S8KUnA6plB3cCmCMUZPyQ",
+          "kty" : "EC",
+          "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+          "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c"
+        }
+      },
+      "output": "fffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364140"
+    },
+    {
+      "description" : "converts noble ecdsa vector 3 to the expected byte array",
+      "input"       : {
+        "privateKey": {
+          "crv" : "secp256k1",
+          "d" : "AAAAAAAAAAAAAAAAAAByRhdKsekukUnG5Eb-GU0HJjc",
+          "kid" : "IJxfsScP6p4G8L9Yf8mYI8WIS87ulINKi0oUbS670KQ",
+          "kty" : "EC",
+          "x" : "tILZZWpOmaFc_atei0h8sHIG3xy4OvsHbG97qJCkNoE",
+          "y": "g-vgQCnVwDMAxAHbZapqnb1Hm05gvdGQoZzltVMgE9I"
+        }
+      },
+      "output": "00000000000000000000000000007246174ab1e92e9149c6e446fe194d072637"
+    },
+    {
+      "description" : "converts byte array bytes to the expected byte array JWK",
+      "input"       : {
+        "privateKey": {
+          "crv" : "secp256k1",
+          "d" : "u0IifnKw8mB8eBCoFLZ5baNp6dwiuFtzng65JLdwzVE",
+          "kid" : "ikH9Jgh0U90gMJQ1txhlaST6VOdP_ygPJNN0JPaAwTI",
+          "kty" : "EC",
+          "x" : "9zVCTdMxpNyy3W1l0VfLdkpQyFdkXvDA0Jpx3TTn1og",
+          "y": "lNsXBQzhcrrGrf9XZYri_LLN1Bye4PdfTaoHbC6PIGI"
+        }
+      },
+      "output": "bb42227e72b0f2607c7810a814b6796da369e9dc22b85b739e0eb924b770cd51"
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/public-key-to-bytes.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/public-key-to-bytes.json
@@ -1,0 +1,57 @@
+{
+  "description" : "Secp256k1 publicKeyToBytes test vectors",
+  "vectors"     : [
+    {
+      "description" : "converts wycheproof vector 1 to the expected byte array",
+      "input"       : {
+        "publicKey": {
+          "crv" : "secp256k1",
+          "kid" : "2JF8vg9etJzjFwZwmkvhBLLZ0bfMVVOPivYR5lFtcec",
+          "kty" : "EC",
+          "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+          "y": "SDradyajxGVdpPv8DhEIqP0XtEimhVQZnEfQj_sQ1Lg"
+        }
+      },
+      "output": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8"
+    },
+    {
+      "description" : "converts wycheproof vector 2 to the expected byte array",
+      "input"       : {
+        "publicKey": {
+          "crv" : "secp256k1",
+          "kid" : "A5kvmZN8g_rnvmmIfgTaV8S8KUnA6plB3cCmCMUZPyQ",
+          "kty" : "EC",
+          "x" : "eb5mfvncu6xVoGKVzocLBwKb_NstzijZWfKBWxb4F5g",
+          "y": "t8UliNlcO5qiWwQD8e73VwLoS7dZeqvmY7gvbwTvJ3c"
+        }
+      },
+      "output": "0479be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798b7c52588d95c3b9aa25b0403f1eef75702e84bb7597aabe663b82f6f04ef2777"
+    },
+    {
+      "description" : "converts wycheproof vector 3 to the expected byte array",
+      "input"       : {
+        "publicKey": {
+          "crv" : "secp256k1",
+          "kid" : "IJxfsScP6p4G8L9Yf8mYI8WIS87ulINKi0oUbS670KQ",
+          "kty" : "EC",
+          "x" : "tILZZWpOmaFc_atei0h8sHIG3xy4OvsHbG97qJCkNoE",
+          "y": "g-vgQCnVwDMAxAHbZapqnb1Hm05gvdGQoZzltVMgE9I"
+        }
+      },
+      "output": "04b482d9656a4e99a15cfdab5e8b487cb07206df1cb83afb076c6f7ba890a4368183ebe04029d5c03300c401db65aa6a9dbd479b4e60bdd190a19ce5b5532013d2"
+    },
+    {
+      "description" : "converts byte array bytes to the expected byte array JWK",
+      "input"       : {
+        "publicKey": {
+          "crv" : "secp256k1",
+          "kid" : "ikH9Jgh0U90gMJQ1txhlaST6VOdP_ygPJNN0JPaAwTI",
+          "kty" : "EC",
+          "x" : "9zVCTdMxpNyy3W1l0VfLdkpQyFdkXvDA0Jpx3TTn1og",
+          "y": "lNsXBQzhcrrGrf9XZYri_LLN1Bye4PdfTaoHbC6PIGI"
+        }
+      },
+      "output": "04f735424dd331a4dcb2dd6d65d157cb764a50c857645ef0c0d09a71dd34e7d68894db17050ce172bac6adff57658ae2fcb2cdd41c9ee0f75f4daa076c2e8f2062"
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/validate-private-key.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/validate-private-key.json
@@ -1,0 +1,33 @@
+{
+  "description" : "Secp256k1 validatePrivateKey test vectors",
+  "vectors"     : [
+    {
+      "description" : "returns true for valid private keys",
+      "input"       : {
+        "key": "740ec69810de9ad1b8f298f1d2c0e6a52dd1e958dc2afc85764bec169c222e88"
+      },
+      "output": true
+    },
+    {
+      "description" : "returns false for invalid private keys",
+      "input"       : {
+        "key": "02fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+      },
+      "output": false
+    },
+    {
+      "description" : "returns false if an compressed public key is given",
+      "input"       : {
+        "key": "026bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce214"
+      },
+      "output": false
+    },
+    {
+      "description" : "returns false if an uncompressed public key is given",
+      "input"       : {
+        "key": "043752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"
+      },
+      "output": false
+    }
+  ]
+}

--- a/Tests/tbDEXTests/TestVectors/secp256k1/validate-public-key.json
+++ b/Tests/tbDEXTests/TestVectors/secp256k1/validate-public-key.json
@@ -1,0 +1,33 @@
+{
+  "description" : "Secp256k1 validatePublicKey test vectors",
+  "vectors"     : [
+    {
+      "description" : "returns true for valid compressed public keys",
+      "input"       : {
+        "key": "026bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce214"
+      },
+      "output": true
+    },
+    {
+      "description" : "returns true for valid uncompressed public keys",
+      "input"       : {
+        "key": "043752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"
+      },
+      "output": true
+    },
+    {
+      "description" : "returns false for invalid public keys",
+      "input"       : {
+        "key": "02fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f"
+      },
+      "output": false
+    },
+    {
+      "description" : "returns false if a private key is given",
+      "input"       : {
+        "key": "740ec69810de9ad1b8f298f1d2c0e6a52dd1e958dc2afc85764bec169c222e88"
+      },
+      "output": false
+    }
+  ]
+}

--- a/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
+++ b/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
@@ -1,0 +1,257 @@
+import XCTest
+import secp256k1
+
+@testable import tbDEX
+
+final class Secp256k1Tests: XCTestCase {
+
+    func test_generatePrivateKey() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+
+        XCTAssertEqual(privateKey.curve, .secp256k1)
+        XCTAssertEqual(privateKey.keyType, .elliptic)
+        XCTAssertNotNil(privateKey.keyIdentifier)
+        XCTAssertNotNil(privateKey.d)
+        XCTAssertNotNil(privateKey.x)
+        XCTAssertNotNil(privateKey.y)
+    }
+
+    func test_computePublicKey() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+        let publicKey = try Secp256k1.computePublicKey(privateKey: privateKey)
+
+        XCTAssertEqual(publicKey.curve, .secp256k1)
+        XCTAssertEqual(publicKey.keyType, .elliptic)
+        XCTAssertNotNil(publicKey.keyIdentifier)
+        XCTAssertNil(publicKey.d)
+        XCTAssertNotNil(publicKey.x)
+        XCTAssertNotNil(publicKey.y)
+
+        XCTAssertEqual(publicKey.curve, privateKey.curve)
+        XCTAssertEqual(publicKey.keyType, privateKey.keyType)
+        XCTAssertEqual(publicKey.keyIdentifier, privateKey.keyIdentifier)
+        XCTAssertEqual(publicKey.x, privateKey.x)
+        XCTAssertEqual(publicKey.y, privateKey.y)
+    }
+
+    func test_bytesToPrivateKey_returnedInJwkFormat() throws {
+        let privateKeyBytes = Data.fromHexString("740ec69810de9ad1b8f298f1d2c0e6a52dd1e958dc2afc85764bec169c222e88")!
+        let privateKey = try Secp256k1.bytesToPrivateKey(privateKeyBytes)
+
+        XCTAssertEqual(privateKey.curve, .secp256k1)
+        XCTAssertEqual(privateKey.keyType, .elliptic)
+        XCTAssertNotNil(privateKey.keyIdentifier)
+        XCTAssertNotNil(privateKey.d)
+        XCTAssertNotNil(privateKey.x)
+        XCTAssertNotNil(privateKey.y)
+    }
+
+    func test_bytesToPrivateKey_testVectors() throws {
+        let testVector: TestVector<[String: String], Jwk> = try loadTestVector(
+            fileName: "bytes-to-private-key",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let privateKeyBytes = Data.fromHexString(vector.input["privateKeyBytes"]!)!
+            let privateKey = try Secp256k1.bytesToPrivateKey(privateKeyBytes)
+            XCTAssertEqual(privateKey, vector.output)
+        }
+    }
+
+    func test_bytesToPublicKey_returnedInJwkFormat() throws {
+        let publicKeyBytes = Data.fromHexString("043752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553")!
+        let publicKey = try Secp256k1.bytesToPublicKey(publicKeyBytes)
+
+        XCTAssertEqual(publicKey.curve, .secp256k1)
+        XCTAssertEqual(publicKey.keyType, .elliptic)
+        XCTAssertNotNil(publicKey.keyIdentifier)
+        XCTAssertNil(publicKey.d)
+        XCTAssertNotNil(publicKey.x)
+        XCTAssertNotNil(publicKey.y)
+    }
+
+    func test_bytesToPublicKey_testVectors() throws {
+        let testVector: TestVector<[String: String], Jwk> = try loadTestVector(
+            fileName: "bytes-to-public-key",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let privateKeyBytes = Data.fromHexString(vector.input["publicKeyBytes"]!)!
+            let publicKey = try Secp256k1.bytesToPublicKey(privateKeyBytes)
+            XCTAssertEqual(publicKey, vector.output)
+        }
+    }
+
+    func test_compressPublicKey() throws {
+        let compressedPublicKeyBytes = Data.fromHexString("026bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce214")!
+        let uncompressedPublicKeyBytes = Data.fromHexString("046bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce21465062296011dd076ae4e8ce5163ccf69d01496d3147656dcc96645b95211f3c6")!
+
+        let output = try Secp256k1.compressPublicKey(publicKeyBytes: uncompressedPublicKeyBytes)
+        XCTAssertEqual(output.count, 33)
+        XCTAssertEqual(output, compressedPublicKeyBytes)
+    }
+
+    func test_compressPublicKey_throwsForInvalidUncompressedPublickey() throws {
+        let invalidUncompressedPublicKeyBytes = Data.fromHexString("dfebc16793a5737ac51f606a43524df8373c063e41d5a99b2f1530afd987284bd1c7cde1658a9a756e71f44a97b4783ea9dee5ccb7f1447eb4836d8de9bd4f81fd")!
+
+        do {
+            let _ = try Secp256k1.compressPublicKey(publicKeyBytes: invalidUncompressedPublicKeyBytes)
+            XCTFail("Expected function to throw an error")
+        } catch {
+            XCTAssert(true, "Successfully threw an error")
+        }
+    }
+
+    func test_decompressPublicKey() throws {
+        let compressedPublicKeyBytes = Data.fromHexString("026bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce214")!
+        let uncompressedPublicKeyBytes = Data.fromHexString("046bcdccc644b309921d3b0c266183a20786650c1634d34e8dfa1ed74cd66ce21465062296011dd076ae4e8ce5163ccf69d01496d3147656dcc96645b95211f3c6")!
+
+        let output = try Secp256k1.decompressPublicKey(publicKeyBytes: compressedPublicKeyBytes)
+        XCTAssertEqual(output.count, 65)
+        XCTAssertEqual(output, uncompressedPublicKeyBytes)
+    }
+
+    func test_decompressPublicKey_throwsForInvalidCompressedPublicKey() throws {
+        let invalidCompressedPublicKeyBytes = Data.fromHexString("fef0b998921eafb58f49efdeb0adc47123aa28a4042924236f08274d50c72fe7b0")!
+
+        do {
+            let _ = try Secp256k1.decompressPublicKey(publicKeyBytes: invalidCompressedPublicKeyBytes)
+            XCTFail("Excpected function to throw an error")
+        } catch {
+            XCTAssert(true, "Successfully threw an error")
+        }
+    }
+
+    func test_getCurvePoints_testVectors() throws {
+        let testVector: TestVector<[String: String], [String: String]> = try loadTestVector(
+            fileName: "get-curve-points",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let keyBytes = Data.fromHexString(vector.input["key"]!)!
+            let expectedX = Data.fromHexString(vector.output["x"]!)!
+            let expectedY = Data.fromHexString(vector.output["y"]!)!
+
+            let (x, y) = try Secp256k1.getCurvePoints(keyBytes: keyBytes)
+            XCTAssertEqual(x, expectedX)
+            XCTAssertEqual(y, expectedY)
+        }
+    }
+
+    func test_privateKeyToBytes_testVectors() throws {
+        let testVector: TestVector<[String: Jwk], String> = try loadTestVector(
+            fileName: "private-key-to-bytes",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let bytes = try Secp256k1.privateKeyToBytes(vector.input["privateKey"]!)
+            XCTAssertEqual(bytes, Data.fromHexString(vector.output)!)
+        }
+    }
+
+    func test_publicKeyToBytes_testVectors() throws {
+        let testVector: TestVector<[String: Jwk], String> = try loadTestVector(
+            fileName: "public-key-to-bytes",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let bytes = try Secp256k1.publicKeyToBytes(vector.input["publicKey"]!)
+            XCTAssertEqual(bytes, Data.fromHexString(vector.output)!)
+        }
+    }
+
+    func test_sign_returns64ByteSignature() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+        let data = Data([51, 52, 53])
+        let signature = try Secp256k1.sign(privateKey: privateKey, payload: data)
+        XCTAssertEqual(signature.count, 64)
+    }
+
+    func test_validatePrivateKey_testVectors() throws {
+        let testVector: TestVector<[String: String], Bool> = try loadTestVector(
+            fileName: "validate-private-key",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let privateKeyBytes = Data.fromHexString(vector.input["key"]!)!
+            XCTAssertEqual(Secp256k1.validatePrivateKey(privateKeyBytes: privateKeyBytes), vector.output)
+        }
+    }
+
+    func test_validatePublicKey_testVectors() throws {
+        let testVector: TestVector<[String: String], Bool> = try loadTestVector(
+            fileName: "validate-public-key",
+            subdirectory: "secp256k1"
+        )
+
+        for vector in testVector.vectors {
+            let publicKeyBytes = Data.fromHexString(vector.input["key"]!)!
+            XCTAssertEqual(Secp256k1.validatePublicKey(publicKeyBytes: publicKeyBytes), vector.output)
+        }
+    }
+
+    func test_verify() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+        let publickey = try Secp256k1.computePublicKey(privateKey: privateKey)
+
+        let data = Data([51, 52, 53])
+        let signature = try Secp256k1.sign(privateKey: privateKey, payload: data)
+        let isValid = try Secp256k1.verify(publicKey: publickey, signature: signature, signedPayload: data)
+
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verify_returnsFalseIfSignedDataWasMutated() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+        let publickey = try Secp256k1.computePublicKey(privateKey: privateKey)
+
+        let data = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        let signature = try Secp256k1.sign(privateKey: privateKey, payload: data)
+        var isValid = try Secp256k1.verify(publicKey: publickey, signature: signature, signedPayload: data)
+        XCTAssertTrue(isValid)
+
+        // Make a copy and flip the least significant bit of the data
+        var mutatedData = Data(data)
+        mutatedData[0] ^= 1 << 0
+
+        // Verification should now return false, as the given data does not match the data used to generate signature
+        isValid = try Secp256k1.verify(publicKey: publickey, signature: signature, signedPayload: mutatedData)
+        XCTAssertFalse(isValid)
+    }
+
+    func test_verify_returnsFalseIfSignatureWasMutated() throws {
+        let privateKey = try Secp256k1.generatePrivateKey()
+        let publickey = try Secp256k1.computePublicKey(privateKey: privateKey)
+
+        let data = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        let signature = try Secp256k1.sign(privateKey: privateKey, payload: data)
+
+        var isValid = try Secp256k1.verify(publicKey: publickey, signature: signature, signedPayload: data)
+        XCTAssertTrue(isValid)
+
+        // Make a copy and flip the least significant bit of the signature
+        var mutatedSignature = Data(signature)
+        mutatedSignature[0] ^= 1 << 0
+
+        isValid = try Secp256k1.verify(publicKey: publickey, signature: mutatedSignature, signedPayload: data)
+        XCTAssertFalse(isValid)
+    }
+
+    func test_verify_returnsFaleWithSignatureGeneratedUsingDifferentPrivateKey() throws {
+        let privateKeyA = try Secp256k1.generatePrivateKey()
+        let publicKeyB = try Secp256k1.computePublicKey(privateKey: Secp256k1.generatePrivateKey())
+
+        let data = Data([1, 2, 3, 4, 5, 6, 7, 8])
+        let signature = try Secp256k1.sign(privateKey: privateKeyA, payload: data)
+
+        let isValid = try Secp256k1.verify(publicKey: publicKeyB, signature: signature, signedPayload: data)
+        XCTAssertFalse(isValid)
+    }
+
+}


### PR DESCRIPTION
This PR implements secp256k1 key generation, signing, and verification in Swift.

The secp256k1 algorithm is provided by the [secp256k1.swift](https://github.com/GigaBitcoin/secp256k1.swift) package. This PR hooks up that algorithm to the various functions we use in web5/tbDEX to convert to/from JWKs.

This PR also uses the test vectors from [web5-js](https://github.com/TBD54566975/web5-js/tree/main/packages/crypto/tests/fixtures/test-vectors/secp256k1) to ensure compatibility with our other SDKs. Reviewers can skip over these JSON files, as they're just copy pasted from that repo.

I also went ahead and re-created the tests from `web5-js` that _weren't_ covered by the test vectors, just to ensure that Swift was doing things properly.



