### PR TITLE
Define KeyGenerator and Signer protocols

### DIFF
--- a/Sources/tbDEX/crypto/Ed25519.swift
+++ b/Sources/tbDEX/crypto/Ed25519.swift
@@ -6,7 +6,9 @@ import Foundation
 ///
 /// This class uses Apple's CryptoKit, specifically `Curve25519.Signing`, for it's cryptographic operations:
 /// https://developer.apple.com/documentation/cryptokit/curve25519/signing
-public enum Ed25519 {
+public enum Ed25519: KeyGenerator, Signer {
+
+    static let keyType: KeyType = .ed25519
 
     // MARK: - Public Functions
 
@@ -40,7 +42,7 @@ public enum Ed25519 {
     }
 
     /// Converts a private key from JSON Web Key (JWK) format to a raw bytes.
-    public static func privateKeyToBytes(privateKey: Jwk) throws -> Data {
+    public static func privateKeyToBytes(_ privateKey: Jwk) throws -> Data {
         guard let d = privateKey.d else {
             throw Ed25519Error.invalidPrivateJwk
         }
@@ -49,7 +51,7 @@ public enum Ed25519 {
     }
 
     /// Converts a public key from JSON Web Key (JWK) format to a raw bytes.
-    public static func publicKeyToBytes(publicKey: Jwk) throws -> Data {
+    public static func publicKeyToBytes(_ publicKey: Jwk) throws -> Data {
         guard let x = publicKey.x else {
             throw Ed25519Error.invalidPublicJwk
         }

--- a/Sources/tbDEX/crypto/KeyGenerator.swift
+++ b/Sources/tbDEX/crypto/KeyGenerator.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+protocol KeyGenerator {
+
+    /// Indicates the `KeyType` intended to bse used with the key.
+    static var keyType: KeyType { get }
+
+    /// Generates a private key.
+    static func generatePrivateKey() throws -> Jwk
+
+    /// Derives a public key from the private key provided.
+    static func computePublicKey(privateKey: Jwk) throws -> Jwk
+
+    /// Converts a private key to bytes.
+    static func privateKeyToBytes(_ privateKey: Jwk) throws -> Data
+
+    /// Converts a public key to bytes.
+    static func publicKeyToBytes(_ publicKey: Jwk) throws -> Data
+
+    /// Converts a private key as bytes into a JWK.
+    static func bytesToPrivateKey(_ bytes: Data) throws -> Jwk
+
+    /// Converts a public key as bytes into a JWK.
+    static func bytesToPublicKey(_ bytes: Data) throws -> Jwk
+}

--- a/Sources/tbDEX/crypto/KeyManager.swift
+++ b/Sources/tbDEX/crypto/KeyManager.swift
@@ -37,7 +37,7 @@ public protocol KeyManager {
     ///   - keyAlias: The alias referencing the stored private key.
     ///   - payload: The data to be signed
     /// - Returns: The signature in JWS R+S format
-    func sign(keyAlias: String, payload: Data) throws -> Data
+    func sign<D>(keyAlias: String, payload: D) throws -> Data where D: DataProtocol
 
     /// Return the alias of `publicKey`, as was originally returned by `generatePrivateKey`.
     /// 

--- a/Sources/tbDEX/crypto/Secp256k1.swift
+++ b/Sources/tbDEX/crypto/Secp256k1.swift
@@ -1,7 +1,9 @@
 import Foundation
 import secp256k1
 
-public enum Secp256k1 {
+public enum Secp256k1: KeyGenerator, Signer {
+
+    static let keyType: KeyType = .secp256k1
 
     // MARK: - Constants
 

--- a/Sources/tbDEX/crypto/Signer.swift
+++ b/Sources/tbDEX/crypto/Signer.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Protocol defining the contract for signing and verifying signatures on payloads
+protocol Signer {
+    
+    /// Sign a given payload using a private key.
+    ///
+    /// - Parameters:
+    ///   - privateKey: The private key in JWK format to be used for signing.
+    ///   - payload: The payload to be signed.
+    /// - Returns: Data representing the signature
+    static func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol
+
+    /// Verify the signature of a given payload, using a public key.
+    ///
+    /// - Parameters:
+    ///   - publicKey: The public key in JWK format used for verifying the signature.
+    ///   - signature: The signature to be verified against the payload and public key.
+    ///   - signedPayload: The original payload that was signed, to be verified.
+    /// - Returns: Boolean indicating if the publicKey and signature are valid for the given payload.
+    static func verify<S, D>(publicKey: Jwk, signature: S, signedPayload: D) throws -> Bool where S: DataProtocol, D: DataProtocol
+}

--- a/Tests/tbDEXTests/crypto/Ed25519Tests.swift
+++ b/Tests/tbDEXTests/crypto/Ed25519Tests.swift
@@ -14,7 +14,7 @@ final class Ed25519Tests: XCTestCase {
         XCTAssertNotNil(privateKey.x)
 
         // Generated private key should always be 32 bytes in length
-        let privateKeyBytes = try Ed25519.privateKeyToBytes(privateKey: privateKey)
+        let privateKeyBytes = try Ed25519.privateKeyToBytes(privateKey)
         XCTAssertEqual(privateKeyBytes.count, 32)
     }
 
@@ -63,7 +63,7 @@ final class Ed25519Tests: XCTestCase {
         )
 
         for vector in testVector.vectors {
-            let privateKeyBytes = try Ed25519.privateKeyToBytes(privateKey: vector.input["privateKey"]!)
+            let privateKeyBytes = try Ed25519.privateKeyToBytes(vector.input["privateKey"]!)
             XCTAssertEqual(privateKeyBytes, Data.fromHexString(vector.output)!)
         }
     }
@@ -75,7 +75,7 @@ final class Ed25519Tests: XCTestCase {
         )
 
         for vector in testVector.vectors {
-            let publicKeyBytes = try Ed25519.publicKeyToBytes(publicKey: vector.input["publicKey"]!)
+            let publicKeyBytes = try Ed25519.publicKeyToBytes(vector.input["publicKey"]!)
             XCTAssertEqual(publicKeyBytes, Data.fromHexString(vector.output)!)
         }
     }


### PR DESCRIPTION
This PR defines `KeyGenerator` and `Signer` protocols, and implement them on `Ed25519` and `Secp256k1`. 

These protocols will be used in the same way as the Kotlin SDK, to correlate KeyGenerators and Signers for particular keyTypes ([web5-kt example](https://github.com/TBD54566975/web5-kt/blob/main/crypto/src/main/kotlin/web5/sdk/crypto/Crypto.kt#L41-L66)).