### PR TITLE
Use swift-custom-dump's `XCTAssertNoDifference` for test vectors

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/GigaBitcoin/secp256k1.swift.git", from: "0.14.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "0.7.0"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.1.2"),
     ],
     targets: [
         .target(
@@ -27,7 +28,10 @@ let package = Package(
         ),
         .testTarget(
             name: "tbDEXTests",
-            dependencies: ["tbDEX"],
+            dependencies: [
+                "tbDEX",
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+            ],
             resources: [
                 .copy("TestVectors/ed25519"),
                 .copy("TestVectors/secp256k1"),

--- a/Tests/tbDEXTests/crypto/Ed25519Tests.swift
+++ b/Tests/tbDEXTests/crypto/Ed25519Tests.swift
@@ -1,3 +1,4 @@
+import CustomDump
 import XCTest
 
 @testable import tbDEX
@@ -27,7 +28,7 @@ final class Ed25519Tests: XCTestCase {
         for vector in testVector.vectors {
             let privateKeyBytes = Data.fromHexString(vector.input["privateKeyBytes"]!)!
             let privateKey = try Ed25519.shared.bytesToPrivateKey(privateKeyBytes)
-            XCTAssertEqual(privateKey, vector.output)
+            XCTAssertNoDifference(privateKey, vector.output)
         }
     }
 
@@ -40,7 +41,7 @@ final class Ed25519Tests: XCTestCase {
         for vector in testVector.vectors {
             let publicKeyBytes = Data.fromHexString(vector.input["publicKeyBytes"]!)!
             let publicKey = try Ed25519.shared.bytesToPublicKey(publicKeyBytes)
-            XCTAssertEqual(publicKey, vector.output)
+            XCTAssertNoDifference(publicKey, vector.output)
         }
     }
 
@@ -52,7 +53,7 @@ final class Ed25519Tests: XCTestCase {
 
         for vector in testVector.vectors {
             let publicKey = try Ed25519.shared.computePublicKey(privateKey: vector.input["privateKey"]!)
-            XCTAssertEqual(publicKey, vector.output)
+            XCTAssertNoDifference(publicKey, vector.output)
         }
     }
 
@@ -64,7 +65,7 @@ final class Ed25519Tests: XCTestCase {
 
         for vector in testVector.vectors {
             let privateKeyBytes = try Ed25519.shared.privateKeyToBytes(vector.input["privateKey"]!)
-            XCTAssertEqual(privateKeyBytes, Data.fromHexString(vector.output)!)
+            XCTAssertNoDifference(privateKeyBytes, Data.fromHexString(vector.output)!)
         }
     }
 
@@ -76,7 +77,7 @@ final class Ed25519Tests: XCTestCase {
 
         for vector in testVector.vectors {
             let publicKeyBytes = try Ed25519.shared.publicKeyToBytes(vector.input["publicKey"]!)
-            XCTAssertEqual(publicKeyBytes, Data.fromHexString(vector.output)!)
+            XCTAssertNoDifference(publicKeyBytes, Data.fromHexString(vector.output)!)
         }
     }
 
@@ -141,7 +142,7 @@ final class Ed25519Tests: XCTestCase {
                 signature: Data.fromHexString(vector.input.signature)!,
                 signedPayload: Data.fromHexString(vector.input.data)!
             )
-            XCTAssertEqual(isValid, vector.output)
+            XCTAssertNoDifference(isValid, vector.output)
         }
     }
 

--- a/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
+++ b/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import CustomDump
 import secp256k1
+import XCTest
 
 @testable import tbDEX
 
@@ -55,7 +56,7 @@ final class Secp256k1Tests: XCTestCase {
         for vector in testVector.vectors {
             let privateKeyBytes = Data.fromHexString(vector.input["privateKeyBytes"]!)!
             let privateKey = try Secp256k1.shared.bytesToPrivateKey(privateKeyBytes)
-            XCTAssertEqual(privateKey, vector.output)
+            XCTAssertNoDifference(privateKey, vector.output)
         }
     }
 
@@ -82,7 +83,7 @@ final class Secp256k1Tests: XCTestCase {
         for vector in testVector.vectors {
             let privateKeyBytes = Data.fromHexString(vector.input["publicKeyBytes"]!)!
             let publicKey = try Secp256k1.shared.bytesToPublicKey(privateKeyBytes)
-            XCTAssertEqual(publicKey, vector.output)
+            XCTAssertNoDifference(publicKey, vector.output)
         }
     }
 
@@ -191,7 +192,7 @@ final class Secp256k1Tests: XCTestCase {
 
         for vector in testVector.vectors {
             let privateKeyBytes = Data.fromHexString(vector.input["key"]!)!
-            XCTAssertEqual(Secp256k1.shared.validatePrivateKey(privateKeyBytes: privateKeyBytes), vector.output)
+            XCTAssertNoDifference(Secp256k1.shared.validatePrivateKey(privateKeyBytes: privateKeyBytes), vector.output)
         }
     }
 
@@ -203,7 +204,7 @@ final class Secp256k1Tests: XCTestCase {
 
         for vector in testVector.vectors {
             let publicKeyBytes = Data.fromHexString(vector.input["key"]!)!
-            XCTAssertEqual(Secp256k1.shared.validatePublicKey(publicKeyBytes: publicKeyBytes), vector.output)
+            XCTAssertNoDifference(Secp256k1.shared.validatePublicKey(publicKeyBytes: publicKeyBytes), vector.output)
         }
     }
 

--- a/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
+++ b/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
@@ -1,6 +1,6 @@
 import CustomDump
-import secp256k1
 import XCTest
+import secp256k1
 
 @testable import tbDEX
 


### PR DESCRIPTION
Previously, when checking that the computed value matches the test vector's output, I was using `XCTAssertEqual` to check for equivalence.

Our test vectors include some very complex JSON objects. So, when the objects didn't match, the error messages were really difficult to read, and required more brain power than necessary to find the actual differences. 

Pointfree's `swift-custom-dump` package comes with a `XCTAssertNoDifference` function, which nicely formats the actual differences. This will help speed up development time, as we no longer need to search through the verbose error messages when objects don't match. More information about this function can be found [here](https://github.com/pointfreeco/swift-custom-dump/blob/aedcf6f4cd486ccef5b312ccac85d4b3f6e58605/README.md#xctassertnodifference).