### PR TITLE
Did document verification methods

### DIFF
--- a/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
+++ b/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
@@ -33,7 +33,7 @@ struct DidJwk: Did {
             return DidResolution.Result.resolutionError(.methodNotSupported)
         }
 
-        let verifiationMethod = DidVerificationMethod(
+        let verifiationMethod = VerificationMethod(
             id: "\(didUri)#0",
             type: "JsonWebKey2020",
             controller: didUri,
@@ -47,10 +47,10 @@ struct DidJwk: Did {
             ]),
             id: didUri,
             verificationMethod: [verifiationMethod],
-            assertionMethod: [verifiationMethod.id],
-            authentication: [verifiationMethod.id],
-            capabilityDelegation: [verifiationMethod.id],
-            capabilityInvocation: [verifiationMethod.id]
+            assertionMethod: [.referenced(verifiationMethod.id)],
+            authentication: [.referenced(verifiationMethod.id)],
+            capabilityDelegation: [.referenced(verifiationMethod.id)],
+            capabilityInvocation: [.referenced(verifiationMethod.id)]
         )
 
         return DidResolution.Result(didDocument: didDocument)

--- a/Tests/tbDEXTests/Dids/DidDocumentTests.swift
+++ b/Tests/tbDEXTests/Dids/DidDocumentTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+@testable import tbDEX
+
+final class DidDocumentTests: XCTestCase {
+
+
+    func test_embeddedVerifiationMethod() {
+        let value = EmbeddedOrReferencedVerificationMethod.embedded(TestData.verificationMethod)
+        XCTAssertEqual(value.dereferenced(with: TestData.didDocument), TestData.verificationMethod)
+    }
+
+    func test_referencedVerificationMethod_absoluteUriString() {
+        let value = EmbeddedOrReferencedVerificationMethod.referenced("did:example:123456789abcdefghi#key-1")
+        XCTAssertEqual(value.dereferenced(with: TestData.didDocument), TestData.verificationMethod)
+    }
+
+    func test_referencedVerificationMethod_fragmentString() {
+        let value = EmbeddedOrReferencedVerificationMethod.referenced("#key-1")
+        XCTAssertEqual(value.dereferenced(with: TestData.didDocument), TestData.verificationMethod)
+    }
+
+}
+
+
+private enum TestData {
+
+    static let verificationMethod = VerificationMethod(
+        id: "did:example:123456789abcdefghi#key-1",
+        type: "type",
+        controller: "did:example:123456789abcdefghi"
+    )
+
+    static let didDocument = DidDocument(
+        id: "did:example:123456789abcdefghi",
+        verificationMethod: [Self.verificationMethod]
+    )
+
+}

--- a/Tests/tbDEXTests/Dids/DidDocumentTests.swift
+++ b/Tests/tbDEXTests/Dids/DidDocumentTests.swift
@@ -4,7 +4,6 @@ import XCTest
 
 final class DidDocumentTests: XCTestCase {
 
-
     func test_embeddedVerifiationMethod() {
         let value = EmbeddedOrReferencedVerificationMethod.embedded(TestData.verificationMethod)
         XCTAssertEqual(value.dereferenced(with: TestData.didDocument), TestData.verificationMethod)
@@ -21,7 +20,6 @@ final class DidDocumentTests: XCTestCase {
     }
 
 }
-
 
 private enum TestData {
 

--- a/Tests/tbDEXTests/Dids/DidJwkTests.swift
+++ b/Tests/tbDEXTests/Dids/DidJwkTests.swift
@@ -56,10 +56,10 @@ final class DidJwkTests: XCTestCase {
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didJwk.uri)
         XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJwk.uri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, "\(didJwk.uri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, "\(didJwk.uri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, "\(didJwk.uri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, "\(didJwk.uri)#0")
+        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, .referenced("\(didJwk.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, .referenced("\(didJwk.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, .referenced("\(didJwk.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, .referenced("\(didJwk.uri)#0"))
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
     }
 
@@ -71,10 +71,10 @@ final class DidJwkTests: XCTestCase {
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didUri)
         XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didUri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, "\(didUri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, "\(didUri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, "\(didUri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, "\(didUri)#0")
+        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, .referenced("\(didUri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, .referenced("\(didUri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, .referenced("\(didUri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, .referenced("\(didUri)#0"))
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
     }
 


### PR DESCRIPTION
`assertionMethod`, `authentication`, `keyAgreement`, `capabilityDelegation`, and `capabilityInvocation` can be either:
* A `String` reference to a `verificationMethod`
* An embedded `VerificationMethod` object itself

Previously, this wasn't supported. Now it is.