### PR TITLE
Naming fixes

### DIFF
--- a/Sources/tbDEX/Dids/Did.swift
+++ b/Sources/tbDEX/Dids/Did.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-protocol Did {
+protocol DID {
     var uri: String { get }
     var keyManager: KeyManager { get }
 }

--- a/Sources/tbDEX/Dids/DidDocument.swift
+++ b/Sources/tbDEX/Dids/DidDocument.swift
@@ -11,7 +11,7 @@ import Foundation
 ///   repository services.
 ///
 /// A DID Document can be retrieved by _resolving_ a DID URI
-struct DidDocument: Codable, Equatable {
+struct DIDDocument: Codable, Equatable {
 
     let context: OneOrMany<String>?
 
@@ -276,7 +276,7 @@ enum EmbeddedOrReferencedVerificationMethod: Codable, Equatable {
     case embedded(VerificationMethod)
     case referenced(String)
 
-    func dereferenced(with didDocument: DidDocument) -> VerificationMethod? {
+    func dereferenced(with didDocument: DIDDocument) -> VerificationMethod? {
         switch self {
         case let .embedded(verificationMethod):
             return verificationMethod

--- a/Sources/tbDEX/Dids/DidDocument.swift
+++ b/Sources/tbDEX/Dids/DidDocument.swift
@@ -232,7 +232,7 @@ struct VerificationMethod: Codable, Equatable {
     let id: String
     let type: String
     let controller: String
-    let publicKeyJwk: Jwk?
+    let publicKeyJWK: JWK?
     let publicKeyMultibase: String?
 
     /// Computed property that returns the absolute ID of the verification method.
@@ -248,13 +248,13 @@ struct VerificationMethod: Codable, Equatable {
         id: String,
         type: String,
         controller: String,
-        publicKeyJwk: Jwk? = nil,
+        publicKeyJWK: JWK? = nil,
         publicKeyMultibase: String? = nil
     ) {
         self.id = id
         self.type = type
         self.controller = controller
-        self.publicKeyJwk = publicKeyJwk
+        self.publicKeyJWK = publicKeyJWK
         self.publicKeyMultibase = publicKeyMultibase
     }
 }

--- a/Sources/tbDEX/Dids/DidResolution.swift
+++ b/Sources/tbDEX/Dids/DidResolution.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-enum DidResolution {
+enum DIDResolution {
 
     /// Errors that can occur during DID resolution process
     enum Error: String {
-        case invalidDid
+        case invalidDID = "invalidDid"
         case methodNotSupported
         case notFound
     }
@@ -18,40 +18,40 @@ enum DidResolution {
         ///
         /// This includes information about the resolution process itself, such as any errors
         /// that occurred. If not provided in the constructor, it defaults to an empty
-        /// `DidResolution.Metadata`.
-        let didResolutionMetadata: DidResolution.Metadata
+        /// `DIDResolution.Metadata`.
+        let didResolutionMetadata: DIDResolution.Metadata
 
         /// The resolved DID document, if available.
         ///
         /// This is the document that represents the resolved state of the DID. It may be `null`
         /// if the DID could not be resolved or if the document is not available.
-        let didDocument: DidDocument?
+        let didDocument: DIDDocument?
 
         /// The metadata associated with the DID document.
         ///
         /// This includes information about the document such as when it was created and
         /// any other relevant metadata. If not provided in the constructor, it defaults to an
-        /// empty `DidDocument.Metadata`.
-        let didDocumentMetadata: DidDocument.Metadata
+        /// empty `DIDDocument.Metadata`.
+        let didDocumentMetadata: DIDDocument.Metadata
 
         init(
-            didResolutionMetadata: DidResolution.Metadata = DidResolution.Metadata(),
-            didDocument: DidDocument? = nil,
-            didDocumentMetadata: DidDocument.Metadata = DidDocument.Metadata()
+            didResolutionMetadata: DIDResolution.Metadata = DIDResolution.Metadata(),
+            didDocument: DIDDocument? = nil,
+            didDocumentMetadata: DIDDocument.Metadata = DIDDocument.Metadata()
         ) {
             self.didResolutionMetadata = didResolutionMetadata
             self.didDocument = didDocument
             self.didDocumentMetadata = didDocumentMetadata
         }
 
-        /// Convenience function to create a `DidResolution.Result` with an error
+        /// Convenience function to create a `DIDResolution.Result` with an error
         /// - Parameter error: Specific error which caused DID to not resolve
-        /// - Returns: DidResolution.Result with appropriate error metadata
-        static func resolutionError(_ error: DidResolution.Error) -> Result {
+        /// - Returns: DIDResolution.Result with appropriate error metadata
+        static func resolutionError(_ error: DIDResolution.Error) -> Result {
             Result(
                 didResolutionMetadata: Metadata(error: error.rawValue),
                 didDocument: nil,
-                didDocumentMetadata: DidDocument.Metadata()
+                didDocumentMetadata: DIDDocument.Metadata()
             )
         }
     }

--- a/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
+++ b/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct DidJWK: Did {
+struct DIDJWK: DID {
 
     struct Options {
         let algorithm: JWK.Algorithm
@@ -19,18 +19,18 @@ struct DidJWK: Did {
         self.keyManager = keyManager
     }
 
-    /// Resolves a `did:jwk` URI into a `DidResolution.Result`
+    /// Resolves a `did:jwk` URI into a `DIDResolution.Result`
     /// - Parameter didUri: The DID URI to resolve
-    /// - Returns: `DidResolution.Result` containing the resolved DID Document.
-    static func resolve(didUri: String) -> DidResolution.Result {
-        guard let parsedDid = try? ParsedDid(didUri: didUri),
-            let jwk = try? JSONDecoder().decode(JWK.self, from: try parsedDid.methodSpecificId.decodeBase64Url())
+    /// - Returns: `DIDResolution.Result` containing the resolved DID Document.
+    static func resolve(didUri: String) -> DIDResolution.Result {
+        guard let parsedDID = try? ParsedDID(didUri: didUri),
+            let jwk = try? JSONDecoder().decode(JWK.self, from: try parsedDID.methodSpecificId.decodeBase64Url())
         else {
-            return DidResolution.Result.resolutionError(.invalidDid)
+            return DIDResolution.Result.resolutionError(.invalidDID)
         }
 
-        guard parsedDid.methodName == "jwk" else {
-            return DidResolution.Result.resolutionError(.methodNotSupported)
+        guard parsedDID.methodName == "jwk" else {
+            return DIDResolution.Result.resolutionError(.methodNotSupported)
         }
 
         let verifiationMethod = VerificationMethod(
@@ -40,7 +40,7 @@ struct DidJWK: Did {
             publicKeyJWK: jwk
         )
 
-        let didDocument = DidDocument(
+        let didDocument = DIDDocument(
             context: .many([
                 "https://www.w3.org/ns/did/v1",
                 "https://w3id.org/security/suites/jws-2020/v1",
@@ -53,6 +53,6 @@ struct DidJWK: Did {
             capabilityInvocation: [.referenced(verifiationMethod.id)]
         )
 
-        return DidResolution.Result(didDocument: didDocument)
+        return DIDResolution.Result(didDocument: didDocument)
     }
 }

--- a/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
+++ b/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
@@ -1,10 +1,10 @@
 import Foundation
 
-struct DidJwk: Did {
+struct DidJWK: Did {
 
     struct Options {
-        let algorithm: Jwk.Algorithm
-        let curve: Jwk.Curve
+        let algorithm: JWK.Algorithm
+        let curve: JWK.Curve
     }
 
     let uri: String
@@ -24,7 +24,7 @@ struct DidJwk: Did {
     /// - Returns: `DidResolution.Result` containing the resolved DID Document.
     static func resolve(didUri: String) -> DidResolution.Result {
         guard let parsedDid = try? ParsedDid(didUri: didUri),
-            let jwk = try? JSONDecoder().decode(Jwk.self, from: try parsedDid.methodSpecificId.decodeBase64Url())
+            let jwk = try? JSONDecoder().decode(JWK.self, from: try parsedDid.methodSpecificId.decodeBase64Url())
         else {
             return DidResolution.Result.resolutionError(.invalidDid)
         }
@@ -37,7 +37,7 @@ struct DidJwk: Did {
             id: "\(didUri)#0",
             type: "JsonWebKey2020",
             controller: didUri,
-            publicKeyJwk: jwk
+            publicKeyJWK: jwk
         )
 
         let didDocument = DidDocument(

--- a/Sources/tbDEX/Dids/Methods/Web/DidWeb.swift
+++ b/Sources/tbDEX/Dids/Methods/Web/DidWeb.swift
@@ -1,29 +1,29 @@
 import Foundation
 
-struct DidWeb {
+struct DIDWeb {
 
     // MARK: - Public Static
 
-    /// Resolves a `did:jwk` URI into a `DidResolution.Result`
+    /// Resolves a `did:jwk` URI into a `DIDResolution.Result`
     /// - Parameter didUri: The DID URI to resolve
-    /// - Returns: `DidResolution.Result` containing the resolved DID Document.
-    static func resolve(didUri: String) async -> DidResolution.Result {
-        guard let parsedDid = try? ParsedDid(didUri: didUri),
-            let url = getDidDocumentUrl(methodSpecificId: parsedDid.methodSpecificId)
+    /// - Returns: `DIDResolution.Result` containing the resolved DID Document.
+    static func resolve(didUri: String) async -> DIDResolution.Result {
+        guard let parsedDID = try? ParsedDID(didUri: didUri),
+            let url = getDIDDocumentUrl(methodSpecificId: parsedDID.methodSpecificId)
         else {
-            return DidResolution.Result.resolutionError(.invalidDid)
+            return DIDResolution.Result.resolutionError(.invalidDID)
         }
 
-        guard parsedDid.methodName == "web" else {
-            return DidResolution.Result.resolutionError(.methodNotSupported)
+        guard parsedDID.methodName == "web" else {
+            return DIDResolution.Result.resolutionError(.methodNotSupported)
         }
 
         do {
             let response = try await URLSession.shared.data(from: url)
-            let didDocument = try JSONDecoder().decode(DidDocument.self, from: response.0)
-            return DidResolution.Result(didDocument: didDocument)
+            let didDocument = try JSONDecoder().decode(DIDDocument.self, from: response.0)
+            return DIDResolution.Result(didDocument: didDocument)
         } catch {
-            return DidResolution.Result.resolutionError(.notFound)
+            return DIDResolution.Result.resolutionError(.notFound)
         }
     }
 
@@ -32,7 +32,7 @@ struct DidWeb {
     private static let wellKnownPath = "/.well-known"
     private static let didDocumentFilename = "/did.json"
 
-    private static func getDidDocumentUrl(methodSpecificId: String) -> URL? {
+    private static func getDIDDocumentUrl(methodSpecificId: String) -> URL? {
         let domainNameWithPath = methodSpecificId.replacingOccurrences(of: ":", with: "/")
         guard let decodedDomain = domainNameWithPath.removingPercentEncoding,
             var url = URL(string: "https://\(decodedDomain)")

--- a/Sources/tbDEX/Dids/ParsedDid.swift
+++ b/Sources/tbDEX/Dids/ParsedDid.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-enum ParsedDidError: Error {
+enum ParsedDIDError: Error {
     case invalidUri
     case invalidMethodName
     case invalidMethodSpecificId
@@ -8,7 +8,7 @@ enum ParsedDidError: Error {
 
 /// Parsed Decentralized Identifier (DID), according to the specifications
 /// defined by the [W3C DID Core specification](https://www.w3.org/TR/did-core).
-struct ParsedDid {
+struct ParsedDID {
 
     /// The complete DID URI.
     private(set) var uri: String
@@ -26,22 +26,22 @@ struct ParsedDid {
     /// Parses a DID URI in accordance to the ABNF rules specified in the specification
     /// [here](https://www.w3.org/TR/did-core/#did-syntax).
     /// - Parameter didUri: URI of DID to parse
-    /// - Returns: `ParsedDid` instance if parsing was successful. Throws error otherwise.
+    /// - Returns: `ParsedDID` instance if parsing was successful. Throws error otherwise.
     init(didUri: String) throws {
         let components = didUri.components(separatedBy: ":")
 
         guard components.count >= 3 else {
-            throw ParsedDidError.invalidUri
+            throw ParsedDIDError.invalidUri
         }
 
         let methodName = components[1]
         guard Self.isValidMethodName(methodName) else {
-            throw ParsedDidError.invalidMethodName
+            throw ParsedDIDError.invalidMethodName
         }
 
         let methodSpecificId = components.dropFirst(2).joined(separator: ":")
         guard Self.isValidMethodSpecificId(methodSpecificId) else {
-            throw ParsedDidError.invalidMethodSpecificId
+            throw ParsedDIDError.invalidMethodSpecificId
         }
 
         self.uri = didUri

--- a/Sources/tbDEX/crypto/Crypto.swift
+++ b/Sources/tbDEX/crypto/Crypto.swift
@@ -11,7 +11,7 @@ enum Crypto {
     ///   - algorithm: The JWA algorithm identifier.
     ///   - curve: The elliptic curve. Null for algorithms that do not use elliptic curves.
     /// - Returns: The generated private key as a JWK object.
-    static func generatePrivateKey(algorithm: Jwk.Algorithm, curve: Jwk.Curve? = nil) throws -> Jwk {
+    static func generatePrivateKey(algorithm: JWK.Algorithm, curve: JWK.Curve? = nil) throws -> JWK {
         let keyGenerator = try getKeyGenerator(algorithm: algorithm, curve: curve)
         return try keyGenerator.generatePrivateKey()
     }
@@ -19,7 +19,7 @@ enum Crypto {
     /// Computes a public key from the given private key, utilizing relevant `KeyGenerator`.
     /// - Parameter privateKey: The private key used to compute the public key.
     /// - Returns: The computed public key as a JWK object.
-    static func computePublicKey(privateKey: Jwk) throws -> Jwk {
+    static func computePublicKey(privateKey: JWK) throws -> JWK {
         let keyGenerator = try getKeyGenerator(algorithm: privateKey.algorithm, curve: privateKey.curve)
         return try keyGenerator.computePublicKey(privateKey: privateKey)
     }
@@ -29,7 +29,7 @@ enum Crypto {
     ///   - privateKey: The JWK private key to be used for generating the signature.
     ///   - payload: The data to be signed.
     /// - Returns: The digital signature as a byte array.
-    static func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol {
+    static func sign<D>(privateKey: JWK, payload: D) throws -> Data where D: DataProtocol {
         let signer = try getSigner(algorithm: privateKey.algorithm, curve: privateKey.curve)
         return try signer.sign(privateKey: privateKey, payload: payload)
     }
@@ -43,20 +43,20 @@ enum Crypto {
     ///   - algorithm: The algorithm used for signing/verification, only used if not provided in the JWK.
     /// - Returns:  Boolean indicating if the publicKey and signature are valid for the given payload.
     static func verify<S, D>(
-        publicKey: Jwk,
+        publicKey: JWK,
         signature: S,
         signedPayload: D,
-        algorithm: Jwk.Algorithm? = nil
+        algorithm: JWK.Algorithm? = nil
     ) throws -> Bool where S: DataProtocol, D: DataProtocol {
         let algorithm = publicKey.algorithm ?? algorithm
         let verifier = try getVerifier(algorithm: algorithm, curve: publicKey.curve)
         return try verifier.verify(publicKey: publicKey, signature: signature, signedPayload: signedPayload)
     }
 
-    /// Converts a `Jwk` public key into its byte array representation.
-    /// - Parameter publicKey: `Jwk` object representing the public key to be converted.
+    /// Converts a `JWK` public key into its byte array representation.
+    /// - Parameter publicKey: `JWK` object representing the public key to be converted.
     /// - Returns: Data representing the byte-level information of the provided public key
-    static func publicKeyToBytes(publicKey: Jwk) throws -> Data {
+    static func publicKeyToBytes(publicKey: JWK) throws -> Data {
         let keyGenerator = try getKeyGenerator(algorithm: publicKey.algorithm, curve: publicKey.curve)
         return try keyGenerator.publicKeyToBytes(publicKey)
     }
@@ -68,7 +68,7 @@ enum Crypto {
     ///   - algorithm: The cryptographic algorithm to find a key generator for.
     ///   - curve: The cryptographic curve to find a key generator for.
     /// - Returns: The corresponding `KeyGenerator`.
-    private static func getKeyGenerator(algorithm: Jwk.Algorithm?, curve: Jwk.Curve? = nil) throws -> KeyGenerator {
+    private static func getKeyGenerator(algorithm: JWK.Algorithm?, curve: JWK.Curve? = nil) throws -> KeyGenerator {
         switch (algorithm, curve) {
         case (nil, .secp256k1),
             (Secp256k1.shared.algorithm, nil),
@@ -84,11 +84,11 @@ enum Crypto {
         }
     }
 
-    private static func getSigner(algorithm: Jwk.Algorithm?, curve: Jwk.Curve? = nil) throws -> Signer {
+    private static func getSigner(algorithm: JWK.Algorithm?, curve: JWK.Curve? = nil) throws -> Signer {
         return try getKeyGenerator(algorithm: algorithm, curve: curve) as! Signer
     }
 
-    private static func getVerifier(algorithm: Jwk.Algorithm?, curve: Jwk.Curve? = nil) throws -> Signer {
+    private static func getVerifier(algorithm: JWK.Algorithm?, curve: JWK.Curve? = nil) throws -> Signer {
         return try getSigner(algorithm: algorithm, curve: curve)
     }
 }

--- a/Sources/tbDEX/crypto/Ed25519.swift
+++ b/Sources/tbDEX/crypto/Ed25519.swift
@@ -16,75 +16,75 @@ class Ed25519 {
 }
 
 enum Ed25519Error: Error {
-    /// The privateJwk provided did not have the appropriate parameters set on it
-    case invalidPrivateJwk
-    /// The publicJwk provided did not have the appropriate parameters set on it
-    case invalidPublicJwk
+    /// The privateJWK provided did not have the appropriate parameters set on it
+    case invalidPrivateJWK
+    /// The publicJWK provided did not have the appropriate parameters set on it
+    case invalidPublicJWK
 }
 
 // MARK: - KeyGenerator
 
 extension Ed25519: KeyGenerator {
 
-    var algorithm: Jwk.Algorithm {
+    var algorithm: JWK.Algorithm {
         .eddsa
     }
 
-    var keyType: Jwk.KeyType {
+    var keyType: JWK.KeyType {
         .octetKeyPair
     }
 
     /// Generates an Ed25519 private key in JSON Web Key (JWK) format.
-    func generatePrivateKey() throws -> Jwk {
-        return try generatePrivateJwk(privateKey: Curve25519.Signing.PrivateKey())
+    func generatePrivateKey() throws -> JWK {
+        return try generatePrivateJWK(privateKey: Curve25519.Signing.PrivateKey())
     }
 
     /// Derives the public key in JSON Web Key (JWK) format from a given Ed25519 private key in JWK format.
-    func computePublicKey(privateKey: Jwk) throws -> Jwk {
+    func computePublicKey(privateKey: JWK) throws -> JWK {
         guard let d = privateKey.d else {
-            throw Ed25519Error.invalidPrivateJwk
+            throw Ed25519Error.invalidPrivateJWK
         }
 
         let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: try d.decodeBase64Url())
-        return try generatePublicJwk(publicKey: privateKey.publicKey)
+        return try generatePublicJWK(publicKey: privateKey.publicKey)
     }
 
     /// Converts a private key from JSON Web Key (JWK) format to a raw bytes.
-    func privateKeyToBytes(_ privateKey: Jwk) throws -> Data {
+    func privateKeyToBytes(_ privateKey: JWK) throws -> Data {
         guard let d = privateKey.d else {
-            throw Ed25519Error.invalidPrivateJwk
+            throw Ed25519Error.invalidPrivateJWK
         }
 
         return try d.decodeBase64Url()
     }
 
     /// Converts a public key from JSON Web Key (JWK) format to a raw bytes.
-    func publicKeyToBytes(_ publicKey: Jwk) throws -> Data {
+    func publicKeyToBytes(_ publicKey: JWK) throws -> Data {
         guard let x = publicKey.x else {
-            throw Ed25519Error.invalidPublicJwk
+            throw Ed25519Error.invalidPublicJWK
         }
 
         return try x.decodeBase64Url()
     }
 
     /// Converts raw private key in bytes to its corresponding JSON Web Key (JWK) format.
-    func bytesToPrivateKey(_ bytes: Data) throws -> Jwk {
-        return try generatePrivateJwk(
+    func bytesToPrivateKey(_ bytes: Data) throws -> JWK {
+        return try generatePrivateJWK(
             privateKey: try Curve25519.Signing.PrivateKey(rawRepresentation: bytes)
         )
     }
 
     /// Converts a raw public key in bytes to its corresponding JSON Web Key (JWK) format.
-    func bytesToPublicKey(_ bytes: Data) throws -> Jwk {
-        return try generatePublicJwk(
+    func bytesToPublicKey(_ bytes: Data) throws -> JWK {
+        return try generatePublicJWK(
             publicKey: try Curve25519.Signing.PublicKey(rawRepresentation: bytes)
         )
     }
 
     // MARK: Private Functions
 
-    private func generatePrivateJwk(privateKey: Curve25519.Signing.PrivateKey) throws -> Jwk {
-        var jwk = Jwk(
+    private func generatePrivateJWK(privateKey: Curve25519.Signing.PrivateKey) throws -> JWK {
+        var jwk = JWK(
             keyType: .octetKeyPair,
             curve: .ed25519,
             d: privateKey.rawRepresentation.base64UrlEncodedString(),
@@ -96,8 +96,8 @@ extension Ed25519: KeyGenerator {
         return jwk
     }
 
-    private func generatePublicJwk(publicKey: Curve25519.Signing.PublicKey) throws -> Jwk {
-        var jwk = Jwk(
+    private func generatePublicJWK(publicKey: Curve25519.Signing.PublicKey) throws -> JWK {
+        var jwk = JWK(
             keyType: .octetKeyPair,
             curve: .ed25519,
             x: publicKey.rawRepresentation.base64UrlEncodedString()
@@ -122,9 +122,9 @@ extension Ed25519: Signer {
     /// See
     /// [Apple's documentation](https://developer.apple.com/documentation/cryptokit/curve25519/signing/privatekey/signature(for:))
     ///  for more information
-    func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol {
+    func sign<D>(privateKey: JWK, payload: D) throws -> Data where D: DataProtocol {
         guard let d = privateKey.d else {
-            throw Ed25519Error.invalidPrivateJwk
+            throw Ed25519Error.invalidPrivateJWK
         }
 
         let privateKey = try Curve25519.Signing.PrivateKey(rawRepresentation: try d.decodeBase64Url())
@@ -133,10 +133,10 @@ extension Ed25519: Signer {
 
     /// Verifies an RFC8032-compliant EdDSA signature against given data using an Ed25519 public key in JSON Web Key
     /// (JWK) format.
-    func verify<S, D>(publicKey: Jwk, signature: S, signedPayload: D) throws -> Bool
+    func verify<S, D>(publicKey: JWK, signature: S, signedPayload: D) throws -> Bool
     where S: DataProtocol, D: DataProtocol {
         guard let x = publicKey.x else {
-            throw Ed25519Error.invalidPublicJwk
+            throw Ed25519Error.invalidPublicJWK
         }
 
         let publicKey = try Curve25519.Signing.PublicKey(rawRepresentation: try x.decodeBase64Url())

--- a/Sources/tbDEX/crypto/InMemoryKeyManager.swift
+++ b/Sources/tbDEX/crypto/InMemoryKeyManager.swift
@@ -3,7 +3,7 @@ import Foundation
 class InMemoryKeyManager {
 
     /// Backing in-memory store to store generated keys.
-    private var keyStore = [String: Jwk]()
+    private var keyStore = [String: JWK]()
 
 }
 
@@ -11,7 +11,7 @@ class InMemoryKeyManager {
 
 extension InMemoryKeyManager: KeyManager {
 
-    func generatePrivateKey(algorithm: Jwk.Algorithm, curve: Jwk.Curve? = nil) throws -> String {
+    func generatePrivateKey(algorithm: JWK.Algorithm, curve: JWK.Curve? = nil) throws -> String {
         let jwk = try Crypto.generatePrivateKey(algorithm: algorithm, curve: curve)
         let alias = try getDeterministicAlias(key: jwk)
         keyStore[alias] = jwk
@@ -19,7 +19,7 @@ extension InMemoryKeyManager: KeyManager {
         return alias
     }
 
-    func getPublicKey(keyAlias: String) throws -> Jwk? {
+    func getPublicKey(keyAlias: String) throws -> JWK? {
         if let privateKey = keyStore[keyAlias] {
             return try Crypto.computePublicKey(privateKey: privateKey)
         } else {
@@ -35,7 +35,7 @@ extension InMemoryKeyManager: KeyManager {
         return try Crypto.sign(privateKey: privateKey, payload: payload)
     }
 
-    func getDeterministicAlias(key: Jwk) throws -> String {
+    func getDeterministicAlias(key: JWK) throws -> String {
         let alias: String
 
         if let keyIdentifier = key.keyIdentifier {

--- a/Sources/tbDEX/crypto/JWK.swift
+++ b/Sources/tbDEX/crypto/JWK.swift
@@ -2,7 +2,7 @@ import CryptoKit
 import ExtrasBase64
 import Foundation
 
-struct Jwk: Codable, Equatable {
+struct JWK: Codable, Equatable {
 
     // MARK: - Types
 
@@ -116,20 +116,20 @@ struct Jwk: Codable, Equatable {
     }
 }
 
-extension Jwk {
+extension JWK {
     func thumbprint() throws -> String {
-        let normalized: Jwk
+        let normalized: JWK
 
         switch keyType {
         case .elliptic:
-            normalized = Jwk(
+            normalized = JWK(
                 keyType: self.keyType,
                 curve: self.curve,
                 x: self.x,
                 y: self.y
             )
         case .octetKeyPair:
-            normalized = Jwk(
+            normalized = JWK(
                 keyType: self.keyType,
                 curve: self.curve,
                 x: self.x

--- a/Sources/tbDEX/crypto/KeyGenerator.swift
+++ b/Sources/tbDEX/crypto/KeyGenerator.swift
@@ -3,26 +3,26 @@ import Foundation
 protocol KeyGenerator {
 
     /// Indicates the algorithm intended to be used with the key.
-    var algorithm: Jwk.Algorithm { get }
+    var algorithm: JWK.Algorithm { get }
 
     /// Indicates the cryptographic algorithm family used with the key.
-    var keyType: Jwk.KeyType { get }
+    var keyType: JWK.KeyType { get }
 
     /// Generates a private key.
-    func generatePrivateKey() throws -> Jwk
+    func generatePrivateKey() throws -> JWK
 
     /// Derives a public key from the private key provided.
-    func computePublicKey(privateKey: Jwk) throws -> Jwk
+    func computePublicKey(privateKey: JWK) throws -> JWK
 
     /// Converts a private key to bytes.
-    func privateKeyToBytes(_ privateKey: Jwk) throws -> Data
+    func privateKeyToBytes(_ privateKey: JWK) throws -> Data
 
     /// Converts a public key to bytes.
-    func publicKeyToBytes(_ publicKey: Jwk) throws -> Data
+    func publicKeyToBytes(_ publicKey: JWK) throws -> Data
 
     /// Converts a private key as bytes into a JWK.
-    func bytesToPrivateKey(_ bytes: Data) throws -> Jwk
+    func bytesToPrivateKey(_ bytes: Data) throws -> JWK
 
     /// Converts a public key as bytes into a JWK.
-    func bytesToPublicKey(_ bytes: Data) throws -> Jwk
+    func bytesToPublicKey(_ bytes: Data) throws -> JWK
 }

--- a/Sources/tbDEX/crypto/KeyManager.swift
+++ b/Sources/tbDEX/crypto/KeyManager.swift
@@ -16,13 +16,13 @@ protocol KeyManager {
     /// - Parameters:
     ///   - algorithm: The cryptographic algorithm to use for key generation.
     ///   - curve: The elliptic curve to use (relevant for EC algorithms).
-    func generatePrivateKey(algorithm: Jwk.Algorithm, curve: Jwk.Curve?) throws -> String
+    func generatePrivateKey(algorithm: JWK.Algorithm, curve: JWK.Curve?) throws -> String
 
     /// Retrieves the public key associated with a previously stored private key, identified by the provided alias.
     ///
     /// - Parameter keyAlias: The alias referencing the stored private key.
     /// - Returns: The associated public key in JSON Web Key (JWK) format (if available).
-    func getPublicKey(keyAlias: String) throws -> Jwk?
+    func getPublicKey(keyAlias: String) throws -> JWK?
 
     /// Signs the provided payload using the private key identified by the provided alias.
     ///
@@ -36,7 +36,7 @@ protocol KeyManager {
     ///
     /// - Parameter key: A key in JSON Web Key (JWK) format
     /// - Returns: The alias belonging to `key`
-    func getDeterministicAlias(key: Jwk) throws -> String
+    func getDeterministicAlias(key: JWK) throws -> String
 }
 
 enum KeyManagerError: Error {

--- a/Sources/tbDEX/crypto/Secp256k1.swift
+++ b/Sources/tbDEX/crypto/Secp256k1.swift
@@ -38,7 +38,7 @@ class Secp256k1 {
         guard publicKeyBytes.count == Self.uncompressedKeySize,
             publicKeyBytes.first == Self.uncompressedKeyID
         else {
-            throw Secpsecp256k1Error.internalError(reason: "Public key must be 65 bytes long an start with 0x04")
+            throw Secp256k1Error.internalError(reason: "Public key must be 65 bytes long an start with 0x04")
         }
 
         let xBytes = publicKeyBytes[1...32]
@@ -104,10 +104,10 @@ class Secp256k1 {
     }
 }
 
-enum Secpsecp256k1Error: Error {
-    /// The private JWK provide did not have the appropriate parameters set on it
+enum Secp256k1Error: Error {
+    /// The privateJWK provide did not have the appropriate parameters set on it
     case invalidPrivateJWK
-    /// The public JWK provide did not have the appropriate parameters set on it
+    /// The publicJWK provide did not have the appropriate parameters set on it
     case invalidPublicJWK
     /// Something internally went wrong, check `reason` for more information about the exact error
     case internalError(reason: String)
@@ -135,7 +135,7 @@ extension Secp256k1: KeyGenerator {
     /// Derives the public key in JSON Web Key (JWK) format from a given Secp256k1 private key in JWK format.
     func computePublicKey(privateKey: JWK) throws -> JWK {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJWK
+            throw Secp256k1Error.invalidPrivateJWK
         }
 
         let privateKeyData = try d.decodeBase64Url()
@@ -147,7 +147,7 @@ extension Secp256k1: KeyGenerator {
     /// Converts a Secp256k1 private key from JSON Web Key (JWK) format to a raw bytes.
     func privateKeyToBytes(_ privateKey: JWK) throws -> Data {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJWK
+            throw Secp256k1Error.invalidPrivateJWK
         }
 
         return try d.decodeBase64Url()
@@ -158,7 +158,7 @@ extension Secp256k1: KeyGenerator {
         guard let x = publicKey.x,
             let y = publicKey.y
         else {
-            throw Secpsecp256k1Error.invalidPublicJWK
+            throw Secp256k1Error.invalidPublicJWK
         }
 
         var data = Data()
@@ -167,7 +167,7 @@ extension Secp256k1: KeyGenerator {
         data.append(contentsOf: try y.decodeBase64Url())
 
         guard data.count == Self.uncompressedKeySize else {
-            throw Secpsecp256k1Error.internalError(reason: "Public Key incorrect size: \(data.count)")
+            throw Secp256k1Error.internalError(reason: "Public Key incorrect size: \(data.count)")
         }
 
         return data
@@ -231,7 +231,7 @@ extension Secp256k1: Signer {
     /// (JWK) format.
     func sign<D>(privateKey: JWK, payload: D) throws -> Data where D: DataProtocol {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJWK
+            throw Secp256k1Error.invalidPrivateJWK
         }
 
         let privateKeyData = try d.decodeBase64Url()

--- a/Sources/tbDEX/crypto/Secp256k1.swift
+++ b/Sources/tbDEX/crypto/Secp256k1.swift
@@ -105,10 +105,10 @@ class Secp256k1 {
 }
 
 enum Secpsecp256k1Error: Error {
-    /// The private Jwk provide did not have the appropriate parameters set on it
-    case invalidPrivateJwk
-    /// The public Jwk provide did not have the appropriate parameters set on it
-    case invalidPublicJwk
+    /// The private JWK provide did not have the appropriate parameters set on it
+    case invalidPrivateJWK
+    /// The public JWK provide did not have the appropriate parameters set on it
+    case invalidPublicJWK
     /// Something internally went wrong, check `reason` for more information about the exact error
     case internalError(reason: String)
 }
@@ -117,48 +117,48 @@ enum Secpsecp256k1Error: Error {
 
 extension Secp256k1: KeyGenerator {
 
-    var algorithm: Jwk.Algorithm {
+    var algorithm: JWK.Algorithm {
         .es256k
     }
 
-    var keyType: Jwk.KeyType {
+    var keyType: JWK.KeyType {
         .elliptic
     }
 
     /// Generates an Secp256k1 private key in JSON Web Key (JWK) format.
-    func generatePrivateKey() throws -> Jwk {
-        return try generatePrivateJwk(
+    func generatePrivateKey() throws -> JWK {
+        return try generatePrivateJWK(
             privateKey: secp256k1.Signing.PrivateKey()
         )
     }
 
     /// Derives the public key in JSON Web Key (JWK) format from a given Secp256k1 private key in JWK format.
-    func computePublicKey(privateKey: Jwk) throws -> Jwk {
+    func computePublicKey(privateKey: JWK) throws -> JWK {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJwk
+            throw Secpsecp256k1Error.invalidPrivateJWK
         }
 
         let privateKeyData = try d.decodeBase64Url()
         let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: privateKeyData)
 
-        return try generatePublicJwk(publicKey: privateKey.publicKey)
+        return try generatePublicJWK(publicKey: privateKey.publicKey)
     }
 
     /// Converts a Secp256k1 private key from JSON Web Key (JWK) format to a raw bytes.
-    func privateKeyToBytes(_ privateKey: Jwk) throws -> Data {
+    func privateKeyToBytes(_ privateKey: JWK) throws -> Data {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJwk
+            throw Secpsecp256k1Error.invalidPrivateJWK
         }
 
         return try d.decodeBase64Url()
     }
 
     /// Converts a Secp256k1 public key from JSON Web Key (JWK) format to a raw bytes.
-    func publicKeyToBytes(_ publicKey: Jwk) throws -> Data {
+    func publicKeyToBytes(_ publicKey: JWK) throws -> Data {
         guard let x = publicKey.x,
             let y = publicKey.y
         else {
-            throw Secpsecp256k1Error.invalidPublicJwk
+            throw Secpsecp256k1Error.invalidPublicJWK
         }
 
         var data = Data()
@@ -174,27 +174,27 @@ extension Secp256k1: KeyGenerator {
     }
 
     /// Converts raw Secp256k1 private key in bytes to its corresponding JSON Web Key (JWK) format.
-    func bytesToPrivateKey(_ bytes: Data) throws -> Jwk {
+    func bytesToPrivateKey(_ bytes: Data) throws -> JWK {
         let privateKey = try secp256k1.Signing.PrivateKey(dataRepresentation: bytes)
-        return try generatePrivateJwk(privateKey: privateKey)
+        return try generatePrivateJWK(privateKey: privateKey)
     }
 
     /// Converts a raw Secp256k1 public key in bytes to its corresponding JSON Web Key (JWK) format.
-    func bytesToPublicKey(_ bytes: Data) throws -> Jwk {
+    func bytesToPublicKey(_ bytes: Data) throws -> JWK {
         let publicKey = try secp256k1.Signing.PublicKey(
             dataRepresentation: bytes,
             format: bytes.isCompressed() ? .compressed : .uncompressed
         )
 
-        return try generatePublicJwk(publicKey: publicKey)
+        return try generatePublicJWK(publicKey: publicKey)
     }
 
     // MARK: Private Functions
 
-    private func generatePrivateJwk(privateKey: secp256k1.Signing.PrivateKey) throws -> Jwk {
+    private func generatePrivateJWK(privateKey: secp256k1.Signing.PrivateKey) throws -> JWK {
         let (x, y) = try getCurvePoints(keyBytes: privateKey.dataRepresentation)
 
-        var jwk = Jwk(
+        var jwk = JWK(
             keyType: .elliptic,
             curve: .secp256k1,
             d: privateKey.dataRepresentation.base64UrlEncodedString(),
@@ -207,10 +207,10 @@ extension Secp256k1: KeyGenerator {
         return jwk
     }
 
-    private func generatePublicJwk(publicKey: secp256k1.Signing.PublicKey) throws -> Jwk {
+    private func generatePublicJWK(publicKey: secp256k1.Signing.PublicKey) throws -> JWK {
         let (x, y) = try getCurvePoints(keyBytes: publicKey.dataRepresentation)
 
-        var jwk = Jwk(
+        var jwk = JWK(
             keyType: .elliptic,
             curve: .secp256k1,
             x: x.base64UrlEncodedString(),
@@ -229,9 +229,9 @@ extension Secp256k1: Signer {
 
     /// Generates an RFC6979-compliant ECDSA signature of given data using a Secp256k1 private key in JSON Web Key
     /// (JWK) format.
-    func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol {
+    func sign<D>(privateKey: JWK, payload: D) throws -> Data where D: DataProtocol {
         guard let d = privateKey.d else {
-            throw Secpsecp256k1Error.invalidPrivateJwk
+            throw Secpsecp256k1Error.invalidPrivateJWK
         }
 
         let privateKeyData = try d.decodeBase64Url()
@@ -244,7 +244,7 @@ extension Secp256k1: Signer {
 
     /// Verifies an RFC6979-compliant ECDSA signature against given data and a Secp256k1 public key in JSON Web Key
     /// (JWK) format.
-    func verify<S, D>(publicKey: Jwk, signature: S, signedPayload: D) throws -> Bool
+    func verify<S, D>(publicKey: JWK, signature: S, signedPayload: D) throws -> Bool
     where S: DataProtocol, D: DataProtocol {
         let publicKeyBytes = try publicKeyToBytes(publicKey)
         let publicKey = try secp256k1.Signing.PublicKey(dataRepresentation: publicKeyBytes, format: .uncompressed)
@@ -267,7 +267,7 @@ extension secp256k1.Signing.PublicKey {
     /// Get the uncompressed bytes for a given public key.
     ///
     /// With a compressed public key, there's no direct access to the y-coordinate for use within
-    /// a Jwk. To avoid doing manual computations along the curve to compute the y-coordinate, this
+    /// a JWK. To avoid doing manual computations along the curve to compute the y-coordinate, this
     /// function offloads the work to the `secp256k1` library to compute it for us.
     fileprivate func uncompressedBytes() -> Data {
         switch self.format {

--- a/Sources/tbDEX/crypto/Signer.swift
+++ b/Sources/tbDEX/crypto/Signer.swift
@@ -9,7 +9,7 @@ protocol Signer {
     ///   - privateKey: The private key in JWK format to be used for signing.
     ///   - payload: The payload to be signed.
     /// - Returns: Data representing the signature
-    func sign<D>(privateKey: Jwk, payload: D) throws -> Data where D: DataProtocol
+    func sign<D>(privateKey: JWK, payload: D) throws -> Data where D: DataProtocol
 
     /// Verify the signature of a given payload, using a public key.
     ///
@@ -18,6 +18,6 @@ protocol Signer {
     ///   - signature: The signature to be verified against the payload and public key.
     ///   - signedPayload: The original payload that was signed, to be verified.
     /// - Returns: Boolean indicating if the publicKey and signature are valid for the given payload.
-    func verify<S, D>(publicKey: Jwk, signature: S, signedPayload: D) throws -> Bool
+    func verify<S, D>(publicKey: JWK, signature: S, signedPayload: D) throws -> Bool
     where S: DataProtocol, D: DataProtocol
 }

--- a/Tests/Web5TestVectors/Resources/did_jwk/resolve.json
+++ b/Tests/Web5TestVectors/Resources/did_jwk/resolve.json
@@ -17,7 +17,7 @@
               "type": "JsonWebKey2020",
               "id": "did:jwk:eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6InNlY3AyNTZrMSIsImtpZCI6ImkzU1BSQnRKS292SEZzQmFxTTkydGk2eFFDSkxYM0U3WUNld2lIVjJDU2ciLCJ4IjoidmRyYnoyRU96dmJMRFZfLWtMNGVKdDdWSS04VEZaTm1BOVlnV3p2aGg3VSIsInkiOiJWTEZxUU1aUF9Bc3B1Y1hvV1gyLWJHWHBBTzFmUTVMbjE5VjVSQXhyZ3ZVIiwiYWxnIjoiRVMyNTZLIn0#0",
               "controller": "did:jwk:eyJrdHkiOiJFQyIsInVzZSI6InNpZyIsImNydiI6InNlY3AyNTZrMSIsImtpZCI6ImkzU1BSQnRKS292SEZzQmFxTTkydGk2eFFDSkxYM0U3WUNld2lIVjJDU2ciLCJ4IjoidmRyYnoyRU96dmJMRFZfLWtMNGVKdDdWSS04VEZaTm1BOVlnV3p2aGg3VSIsInkiOiJWTEZxUU1aUF9Bc3B1Y1hvV1gyLWJHWHBBTzFmUTVMbjE5VjVSQXhyZ3ZVIiwiYWxnIjoiRVMyNTZLIn0",
-              "publicKeyJwk": {
+              "publicKeyJWK": {
                 "kty": "EC",
                 "use": "sig",
                 "crv": "secp256k1",
@@ -62,7 +62,7 @@
               "type": "JsonWebKey2020",
               "id": "did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5Iiwia2lkIjoiVnRTSFhQbEtEdzFFRW9PajVYTjNYV2hqU1BZVk52WC1lNHZqUk8weVlKQSIsIngiOiJpejcwc3ZTTHhOWmhzRHhlSlFfam5PVmJYM0tGTmtjQmNNaldqWm1YRXNBIiwiYWxnIjoiRWREU0EifQ#0",
               "controller": "did:jwk:eyJrdHkiOiJPS1AiLCJ1c2UiOiJzaWciLCJjcnYiOiJFZDI1NTE5Iiwia2lkIjoiVnRTSFhQbEtEdzFFRW9PajVYTjNYV2hqU1BZVk52WC1lNHZqUk8weVlKQSIsIngiOiJpejcwc3ZTTHhOWmhzRHhlSlFfam5PVmJYM0tGTmtjQmNNaldqWm1YRXNBIiwiYWxnIjoiRWREU0EifQ",
-              "publicKeyJwk": {
+              "publicKeyJWK": {
                 "kty": "OKP",
                 "use": "sig",
                 "crv": "Ed25519",

--- a/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
@@ -3,7 +3,7 @@ import XCTest
 
 @testable import tbDEX
 
-final class Web5TestVectorsDidJwk: XCTestCase {
+final class Web5TestVectorsDidJWK: XCTestCase {
 
     func test_resolve() throws {
         let testVector = try TestVector<String, DidResolution.Result>(
@@ -13,7 +13,7 @@ final class Web5TestVectorsDidJwk: XCTestCase {
 
         testVector.run { vector in
             let didUri = vector.input
-            let result = DidJwk.resolve(didUri: didUri)
+            let result = DidJWK.resolve(didUri: didUri)
             XCTAssertNoDifference(result, vector.output)
         }
     }

--- a/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
@@ -3,17 +3,17 @@ import XCTest
 
 @testable import tbDEX
 
-final class Web5TestVectorsDidJWK: XCTestCase {
+final class Web5TestVectorsDidJwk: XCTestCase {
 
     func test_resolve() throws {
-        let testVector = try TestVector<String, DidResolution.Result>(
+        let testVector = try TestVector<String, DIDResolution.Result>(
             fileName: "resolve",
             subdirectory: "did_jwk"
         )
 
         testVector.run { vector in
             let didUri = vector.input
-            let result = DidJWK.resolve(didUri: didUri)
+            let result = DIDJWK.resolve(didUri: didUri)
             XCTAssertNoDifference(result, vector.output)
         }
     }

--- a/Tests/Web5TestVectors/Web5TestVectorsDidWeb.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidWeb.swift
@@ -29,7 +29,7 @@ final class Web5TestVectorsDidWeb: XCTestCase {
             }
         }
 
-        let testVector = try TestVector<Input, DidResolution.Result>(
+        let testVector = try TestVector<Input, DIDResolution.Result>(
             fileName: "resolve",
             subdirectory: "did_web"
         )
@@ -41,7 +41,7 @@ final class Web5TestVectorsDidWeb: XCTestCase {
                 try vector.input.mocks().forEach { $0.register() }
 
                 /// Resolve each input didUri, make sure it matches output
-                let result = await DidWeb.resolve(didUri: vector.input.didUri)
+                let result = await DIDWeb.resolve(didUri: vector.input.didUri)
                 XCTAssertNoDifference(result, vector.output)
                 expectation.fulfill()
             }

--- a/Tests/Web5TestVectors/Web5TestVectorsEd25519.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsEd25519.swift
@@ -12,7 +12,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
             let privateKeyBytes: String
         }
 
-        let testVector = try TestVector<Input, Jwk>(
+        let testVector = try TestVector<Input, JWK>(
             fileName: "bytes-to-private-key",
             subdirectory: "ed25519"
         )
@@ -30,7 +30,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
             let publicKeyBytes: String
         }
 
-        let testVector = try TestVector<Input, Jwk>(
+        let testVector = try TestVector<Input, JWK>(
             fileName: "bytes-to-public-key",
             subdirectory: "ed25519"
         )
@@ -45,10 +45,10 @@ final class Web5TestVectorsEd25519: XCTestCase {
     func test_computePublicKey() throws {
         /// Input data format for `compute-public-key` test vectors
         struct Input: Codable {
-            let privateKey: Jwk
+            let privateKey: JWK
         }
 
-        let testVector = try TestVector<Input, Jwk>(
+        let testVector = try TestVector<Input, JWK>(
             fileName: "compute-public-key",
             subdirectory: "ed25519"
         )
@@ -62,7 +62,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
     func test_privateKeyToBytes() throws {
         /// Input data format for `private-key-to-bytes` test vectors
         struct Input: Codable {
-            let privateKey: Jwk
+            let privateKey: JWK
         }
 
         let testVector = try TestVector<Input, String>(
@@ -79,7 +79,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
     func test_publicKeyToBytes() throws {
         /// Input data format for `public-key-to-bytes` test vectors
         struct Input: Codable {
-            let publicKey: Jwk
+            let publicKey: JWK
         }
 
         let testVector = try TestVector<Input, String>(
@@ -97,7 +97,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
         /// Input data format for `sign` test vectors
         struct Input: Codable {
             let data: String
-            let key: Jwk
+            let key: JWK
         }
 
         let testVector = try TestVector<Input, String>(
@@ -139,7 +139,7 @@ final class Web5TestVectorsEd25519: XCTestCase {
         /// Input data format for `verify` test vectors
         struct Input: Codable {
             let data: String
-            let key: Jwk
+            let key: JWK
             let signature: String
         }
 

--- a/Tests/Web5TestVectors/Web5TestVectorsSecp256k1.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsSecp256k1.swift
@@ -11,7 +11,7 @@ final class Web5TestVectorsSecp256k1: XCTestCase {
             let privateKeyBytes: String
         }
 
-        let testVector = try TestVector<Input, Jwk>(
+        let testVector = try TestVector<Input, JWK>(
             fileName: "bytes-to-private-key",
             subdirectory: "secp256k1"
         )
@@ -29,7 +29,7 @@ final class Web5TestVectorsSecp256k1: XCTestCase {
             let publicKeyBytes: String
         }
 
-        let testVector = try TestVector<Input, Jwk>(
+        let testVector = try TestVector<Input, JWK>(
             fileName: "bytes-to-public-key",
             subdirectory: "secp256k1"
         )
@@ -72,7 +72,7 @@ final class Web5TestVectorsSecp256k1: XCTestCase {
     func test_privateKeyToBytes() throws {
         /// Input data format for `private-key-to-bytes` test vectors
         struct Input: Codable {
-            let privateKey: Jwk
+            let privateKey: JWK
         }
 
         let testVector = try TestVector<Input, String>(
@@ -89,7 +89,7 @@ final class Web5TestVectorsSecp256k1: XCTestCase {
     func test_publicKeyToBytes() throws {
         /// Input data format for `public-key-to-bytes` test vectors
         struct Input: Codable {
-            let publicKey: Jwk
+            let publicKey: JWK
         }
 
         let testVector = try TestVector<Input, String>(

--- a/Tests/tbDEXTests/Dids/DidDocumentTests.swift
+++ b/Tests/tbDEXTests/Dids/DidDocumentTests.swift
@@ -2,7 +2,7 @@ import XCTest
 
 @testable import tbDEX
 
-final class DidDocumentTests: XCTestCase {
+final class DIDDocumentTests: XCTestCase {
 
     func test_embeddedVerifiationMethod() {
         let value = EmbeddedOrReferencedVerificationMethod.embedded(TestData.verificationMethod)
@@ -29,7 +29,7 @@ private enum TestData {
         controller: "did:example:123456789abcdefghi"
     )
 
-    static let didDocument = DidDocument(
+    static let didDocument = DIDDocument(
         id: "did:example:123456789abcdefghi",
         verificationMethod: [Self.verificationMethod]
     )

--- a/Tests/tbDEXTests/Dids/DidJwkTests.swift
+++ b/Tests/tbDEXTests/Dids/DidJwkTests.swift
@@ -2,41 +2,41 @@ import XCTest
 
 @testable import tbDEX
 
-final class DidJwkTests: XCTestCase {
+final class DidJWKTests: XCTestCase {
 
     func test_initializer() throws {
         let keyManager = InMemoryKeyManager()
-        let didJwk = try DidJwk(
+        let didJWK = try DidJWK(
             keyManager: keyManager,
             options: .init(algorithm: .eddsa, curve: .ed25519)
         )
 
-        XCTAssert(didJwk.uri.starts(with: "did:jwk:"))
+        XCTAssert(didJWK.uri.starts(with: "did:jwk:"))
     }
 
     func test_resolveWithError_onInvalidDidUri() throws {
-        let resolutionResult = DidJwk.resolve(didUri: "hi")
+        let resolutionResult = DidJWK.resolve(didUri: "hi")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
-    func test_resolveWithError_ifDidUriNotJwk() {
-        let resolutionResult = DidJwk.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+    func test_resolveWithError_ifDidUriNotJWK() {
+        let resolutionResult = DidJWK.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
     func test_resolveWithError_ifDidUriIsNotValidBase64Url() {
-        let resolutionResult = DidJwk.resolve(didUri: "did:jwk:!!!")
+        let resolutionResult = DidJWK.resolve(didUri: "did:jwk:!!!")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
-    func test_resolveWithError_ifMethodNotJwk() {
-        let resolutionResult = DidJwk.resolve(
+    func test_resolveWithError_ifMethodNotJWK() {
+        let resolutionResult = DidJWK.resolve(
             didUri:
                 "did:web:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
         )
@@ -45,28 +45,28 @@ final class DidJwkTests: XCTestCase {
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.methodNotSupported.rawValue)
     }
 
-    func test_resolveNewlyCratedDidJwk() throws {
+    func test_resolveNewlyCratedDidJWK() throws {
         let keyManager = InMemoryKeyManager()
-        let didJwk = try DidJwk(
+        let didJWK = try DidJWK(
             keyManager: keyManager,
             options: .init(algorithm: .es256k, curve: .secp256k1)
         )
 
-        let resolutionResult = DidJwk.resolve(didUri: didJwk.uri)
+        let resolutionResult = DidJWK.resolve(didUri: didJWK.uri)
         XCTAssertNotNil(resolutionResult.didDocument)
-        XCTAssertEqual(resolutionResult.didDocument?.id, didJwk.uri)
-        XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJwk.uri)#0")
-        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, .referenced("\(didJwk.uri)#0"))
-        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, .referenced("\(didJwk.uri)#0"))
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, .referenced("\(didJwk.uri)#0"))
-        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, .referenced("\(didJwk.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.id, didJWK.uri)
+        XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJWK.uri)#0")
+        XCTAssertEqual(resolutionResult.didDocument?.authentication?.first, .referenced("\(didJWK.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.assertionMethod?.first, .referenced("\(didJWK.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityDelegation?.first, .referenced("\(didJWK.uri)#0"))
+        XCTAssertEqual(resolutionResult.didDocument?.capabilityInvocation?.first, .referenced("\(didJWK.uri)#0"))
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
     }
 
     func test_resolveWithKnownDidUri() {
         let didUri =
             "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
-        let resolutionResult = DidJwk.resolve(didUri: didUri)
+        let resolutionResult = DidJWK.resolve(didUri: didUri)
 
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didUri)

--- a/Tests/tbDEXTests/Dids/DidJwkTests.swift
+++ b/Tests/tbDEXTests/Dids/DidJwkTests.swift
@@ -2,11 +2,11 @@ import XCTest
 
 @testable import tbDEX
 
-final class DidJWKTests: XCTestCase {
+final class DIDJWKTests: XCTestCase {
 
     func test_initializer() throws {
         let keyManager = InMemoryKeyManager()
-        let didJWK = try DidJWK(
+        let didJWK = try DIDJWK(
             keyManager: keyManager,
             options: .init(algorithm: .eddsa, curve: .ed25519)
         )
@@ -14,45 +14,45 @@ final class DidJWKTests: XCTestCase {
         XCTAssert(didJWK.uri.starts(with: "did:jwk:"))
     }
 
-    func test_resolveWithError_onInvalidDidUri() throws {
-        let resolutionResult = DidJWK.resolve(didUri: "hi")
+    func test_resolveWithError_onInvalidDIDUri() throws {
+        let resolutionResult = DIDJWK.resolve(didUri: "hi")
 
         XCTAssertNil(resolutionResult.didDocument)
-        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
+        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolution.Error.invalidDID.rawValue)
     }
 
-    func test_resolveWithError_ifDidUriNotJWK() {
-        let resolutionResult = DidJWK.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+    func test_resolveWithError_ifDIDUriNotJWK() {
+        let resolutionResult = DIDJWK.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
 
         XCTAssertNil(resolutionResult.didDocument)
-        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
+        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolution.Error.invalidDID.rawValue)
     }
 
-    func test_resolveWithError_ifDidUriIsNotValidBase64Url() {
-        let resolutionResult = DidJWK.resolve(didUri: "did:jwk:!!!")
+    func test_resolveWithError_ifDIDUriIsNotValidBase64Url() {
+        let resolutionResult = DIDJWK.resolve(didUri: "did:jwk:!!!")
 
         XCTAssertNil(resolutionResult.didDocument)
-        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
+        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolution.Error.invalidDID.rawValue)
     }
 
     func test_resolveWithError_ifMethodNotJWK() {
-        let resolutionResult = DidJWK.resolve(
+        let resolutionResult = DIDJWK.resolve(
             didUri:
                 "did:web:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
         )
 
         XCTAssertNil(resolutionResult.didDocument)
-        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.methodNotSupported.rawValue)
+        XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DIDResolution.Error.methodNotSupported.rawValue)
     }
 
-    func test_resolveNewlyCratedDidJWK() throws {
+    func test_resolveNewlyCratedDIDJWK() throws {
         let keyManager = InMemoryKeyManager()
-        let didJWK = try DidJWK(
+        let didJWK = try DIDJWK(
             keyManager: keyManager,
             options: .init(algorithm: .es256k, curve: .secp256k1)
         )
 
-        let resolutionResult = DidJWK.resolve(didUri: didJWK.uri)
+        let resolutionResult = DIDJWK.resolve(didUri: didJWK.uri)
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didJWK.uri)
         XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJWK.uri)#0")
@@ -63,10 +63,10 @@ final class DidJWKTests: XCTestCase {
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
     }
 
-    func test_resolveWithKnownDidUri() {
+    func test_resolveWithKnownDIDUri() {
         let didUri =
             "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
-        let resolutionResult = DidJWK.resolve(didUri: didUri)
+        let resolutionResult = DIDJWK.resolve(didUri: didUri)
 
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didUri)

--- a/Tests/tbDEXTests/Dids/ParsedDidTests.swift
+++ b/Tests/tbDEXTests/Dids/ParsedDidTests.swift
@@ -2,19 +2,19 @@ import XCTest
 
 @testable import tbDEX
 
-class ParsedDidTests: XCTestCase {
+class ParsedDIDTests: XCTestCase {
 
     func test_initValidUri() throws {
         let didUri = "did:example:123abc"
-        let parsed = try ParsedDid(didUri: didUri)
+        let parsed = try ParsedDID(didUri: didUri)
         XCTAssertEqual(parsed.uri, didUri)
         XCTAssertEqual(parsed.methodName, "example")
         XCTAssertEqual(parsed.methodSpecificId, "123abc")
     }
 
-    func test_initWithDidWebUriThatContainsPath() throws {
+    func test_initWithDIDWebUriThatContainsPath() throws {
         let didUri = "did:web:w3c-ccg.github.io:user:alice"
-        let parsed = try ParsedDid(didUri: didUri)
+        let parsed = try ParsedDID(didUri: didUri)
         XCTAssertEqual(parsed.uri, didUri)
         XCTAssertEqual(parsed.methodName, "web")
         XCTAssertEqual(parsed.methodSpecificId, "w3c-ccg.github.io:user:alice")
@@ -22,6 +22,6 @@ class ParsedDidTests: XCTestCase {
 
     func test_initInvalidUri() throws {
         let didUri = "invalid:uri"
-        XCTAssertThrowsError(try ParsedDid(didUri: didUri))
+        XCTAssertThrowsError(try ParsedDID(didUri: didUri))
     }
 }

--- a/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
+++ b/Tests/tbDEXTests/crypto/Secp256k1Tests.swift
@@ -36,7 +36,7 @@ final class Secp256k1Tests: XCTestCase {
         XCTAssertEqual(publicKey.y, privateKey.y)
     }
 
-    func test_bytesToPrivateKey_returnedInJwkFormat() throws {
+    func test_bytesToPrivateKey_returnedInJWKFormat() throws {
         let privateKeyBytes = try XCTUnwrap(
             Data.fromHexString("740ec69810de9ad1b8f298f1d2c0e6a52dd1e958dc2afc85764bec169c222e88")
         )
@@ -50,7 +50,7 @@ final class Secp256k1Tests: XCTestCase {
         XCTAssertNotNil(privateKey.y)
     }
 
-    func test_bytesToPublicKey_returnedInJwkFormat() throws {
+    func test_bytesToPublicKey_returnedInJWKFormat() throws {
         let publicKeyBytes = try XCTUnwrap(
             Data.fromHexString(
                 "043752951274023296c8a74b0ffe42f82ff4b4d4bba4326477422703f761f59258c26a7465b9a77ac0c3f1cedb139c428b0b1fbb5516867b527636f3286f705553"


### PR DESCRIPTION
Swift naming conventions suggest to have acronyms that appear in class names in all-caps. This is seen in Apple's APIs for other acronyms, such as `URL`. 

This PR updates our acronym class names to all-caps:
* `Jwk` -> `JWK`
* `Did` -> `DID`

The only exception to this rule is the test vectors, which have their own unique naming convention standards (outlined [here](https://github.com/TBD54566975/sdk-development/tree/main/web5-test-vectors#web5-test-vectors)).