### PR TITLE
Add a DidResolver

### DIFF
--- a/Sources/tbDEX/Dids/DidResolver.swift
+++ b/Sources/tbDEX/Dids/DidResolver.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+typealias DidMethodResolver = (String) async -> DidResolution.Result
+
+enum DidResolver {
+
+    private static var methodResolvers: [String: DidMethodResolver] = [
+        "jwk": DidJwk.resolve,
+        "web": DidWeb.resolve,
+    ]
+
+    /// Resolves a DID URI to its DID Document
+    public static func resolve(didUri: String) async -> DidResolution.Result {
+        guard let parsedDid = try? ParsedDid(didUri: didUri) else {
+            return DidResolution.Result.resolutionError(.invalidDid)
+        }
+
+        guard let methodResolver = methodResolvers[parsedDid.methodName] else {
+            return DidResolution.Result.resolutionError(.methodNotSupported)
+        }
+
+        return await methodResolver(didUri)
+    }
+
+}

--- a/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
+++ b/Sources/tbDEX/Dids/Methods/Jwk/DidJwk.swift
@@ -22,7 +22,7 @@ struct DidJwk: Did {
     /// Resolves a `did:jwk` URI into a `DidResolution.Result`
     /// - Parameter didUri: The DID URI to resolve
     /// - Returns: `DidResolution.Result` containing the resolved DID Document.
-    static func resolve(didUri: String) -> DidResolution.Result {
+    static func resolve(didUri: String) async -> DidResolution.Result {
         guard let parsedDid = try? ParsedDid(didUri: didUri),
             let jwk = try? JSONDecoder().decode(Jwk.self, from: try parsedDid.methodSpecificId.decodeBase64Url())
         else {

--- a/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
+++ b/Tests/Web5TestVectors/Web5TestVectorsDidJwk.swift
@@ -12,9 +12,15 @@ final class Web5TestVectorsDidJwk: XCTestCase {
         )
 
         testVector.run { vector in
-            let didUri = vector.input
-            let result = DidJwk.resolve(didUri: didUri)
-            XCTAssertNoDifference(result, vector.output)
+            let expectation = XCTestExpectation(description: "async resolve")
+            Task {
+                let didUri = vector.input
+                let result = await DidJwk.resolve(didUri: didUri)
+                XCTAssertNoDifference(result, vector.output)
+                expectation.fulfill()
+            }
+
+            wait(for: [expectation], timeout: 1)
         }
     }
 

--- a/Tests/tbDEXTests/Dids/DidJwkTests.swift
+++ b/Tests/tbDEXTests/Dids/DidJwkTests.swift
@@ -14,29 +14,29 @@ final class DidJwkTests: XCTestCase {
         XCTAssert(didJwk.uri.starts(with: "did:jwk:"))
     }
 
-    func test_resolveWithError_onInvalidDidUri() throws {
-        let resolutionResult = DidJwk.resolve(didUri: "hi")
+    func test_resolveWithError_onInvalidDidUri() async throws {
+        let resolutionResult = await DidJwk.resolve(didUri: "hi")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
-    func test_resolveWithError_ifDidUriNotJwk() {
-        let resolutionResult = DidJwk.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
+    func test_resolveWithError_ifDidUriNotJwk() async {
+        let resolutionResult = await DidJwk.resolve(didUri: "did:key:z6MkpTHR8VNsBxYAAWHut2Geadd9jSwuBV8xRoAnwWsdvktH")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
-    func test_resolveWithError_ifDidUriIsNotValidBase64Url() {
-        let resolutionResult = DidJwk.resolve(didUri: "did:jwk:!!!")
+    func test_resolveWithError_ifDidUriIsNotValidBase64Url() async {
+        let resolutionResult = await DidJwk.resolve(didUri: "did:jwk:!!!")
 
         XCTAssertNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.invalidDid.rawValue)
     }
 
-    func test_resolveWithError_ifMethodNotJwk() {
-        let resolutionResult = DidJwk.resolve(
+    func test_resolveWithError_ifMethodNotJwk() async {
+        let resolutionResult = await DidJwk.resolve(
             didUri:
                 "did:web:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
         )
@@ -45,14 +45,14 @@ final class DidJwkTests: XCTestCase {
         XCTAssertEqual(resolutionResult.didResolutionMetadata.error, DidResolution.Error.methodNotSupported.rawValue)
     }
 
-    func test_resolveNewlyCratedDidJwk() throws {
+    func test_resolveNewlyCratedDidJwk() async throws {
         let keyManager = InMemoryKeyManager()
         let didJwk = try DidJwk(
             keyManager: keyManager,
             options: .init(algorithm: .es256k, curve: .secp256k1)
         )
 
-        let resolutionResult = DidJwk.resolve(didUri: didJwk.uri)
+        let resolutionResult = await DidJwk.resolve(didUri: didJwk.uri)
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didJwk.uri)
         XCTAssertEqual(resolutionResult.didDocument?.verificationMethod?.first?.id, "\(didJwk.uri)#0")
@@ -63,10 +63,10 @@ final class DidJwkTests: XCTestCase {
         XCTAssertNil(resolutionResult.didResolutionMetadata.error)
     }
 
-    func test_resolveWithKnownDidUri() {
+    func test_resolveWithKnownDidUri() async {
         let didUri =
             "did:jwk:eyJraWQiOiJ1cm46aWV0ZjpwYXJhbXM6b2F1dGg6andrLXRodW1icHJpbnQ6c2hhLTI1NjpGZk1iek9qTW1RNGVmVDZrdndUSUpqZWxUcWpsMHhqRUlXUTJxb2JzUk1NIiwia3R5IjoiT0tQIiwiY3J2IjoiRWQyNTUxOSIsImFsZyI6IkVkRFNBIiwieCI6IkFOUmpIX3p4Y0tCeHNqUlBVdHpSYnA3RlNWTEtKWFE5QVBYOU1QMWo3azQifQ"
-        let resolutionResult = DidJwk.resolve(didUri: didUri)
+        let resolutionResult = await DidJwk.resolve(didUri: didUri)
 
         XCTAssertNotNil(resolutionResult.didDocument)
         XCTAssertEqual(resolutionResult.didDocument?.id, didUri)


### PR DESCRIPTION
`DidResolver` has a single static function called `resolve`, which resolves a DID URI to its `DidResolution.Result`. If any error occurs during the resolution process, it will be reflected in the Result's `didResolutionMetadata`.

Example usage:
`DidResolver.resolve('did:jwk:1234')`