### PR TITLE
Sign & Verify implementations for Message/Resource

### DIFF
--- a/Sources/tbDEX/Dids/ParsedDid.swift
+++ b/Sources/tbDEX/Dids/ParsedDid.swift
@@ -47,7 +47,8 @@ struct ParsedDid {
     /// - Parameter didUri: URI of DID to parse
     /// - Returns: `ParsedDid` instance if parsing was successful. Throws error otherwise.
     init(didUri: String) throws {
-        let components = didUri
+        let components =
+            didUri
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .components(separatedBy: "#")
             .first!

--- a/Sources/tbDEX/Dids/ParsedDid.swift
+++ b/Sources/tbDEX/Dids/ParsedDid.swift
@@ -11,24 +11,44 @@ enum ParsedDidError: Error {
 struct ParsedDid {
 
     /// The complete DID URI.
-    private(set) var uri: String
+    var uri: String
+
+    var uriWithoutFragment: String {
+        uri.components(separatedBy: "#")[0]
+    }
 
     /// The method name specified in the DID URI.
     ///
     /// Example: if the `uri` is `did:example:123456`, "example" would be the method name
-    private(set) var methodName: String
+    var methodName: String
 
     /// The method specific identifier part of the DID URI.
     ///
     /// Example: if the `uri` is `did:example:123456`, "123456" would be the identifier
-    private(set) var methodSpecificId: String
+    var methodSpecificId: String
+
+    /// The fragment part of the DID URI.
+    ///
+    /// Example: if the `uri` is `did:example:123456#keys-1`, "keys-1" would be the fragment
+    var fragment: String? {
+        let components = uri.components(separatedBy: "#")
+        if components.count == 2 {
+            return components[1]
+        } else {
+            return nil
+        }
+    }
 
     /// Parses a DID URI in accordance to the ABNF rules specified in the specification
     /// [here](https://www.w3.org/TR/did-core/#did-syntax).
     /// - Parameter didUri: URI of DID to parse
     /// - Returns: `ParsedDid` instance if parsing was successful. Throws error otherwise.
     init(didUri: String) throws {
-        let components = didUri.components(separatedBy: ":")
+        let components = didUri
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: "#")
+            .first!
+            .components(separatedBy: ":")
 
         guard components.count >= 3 else {
             throw ParsedDidError.invalidUri

--- a/Sources/tbDEX/Dids/ParsedDid.swift
+++ b/Sources/tbDEX/Dids/ParsedDid.swift
@@ -11,8 +11,11 @@ enum ParsedDidError: Error {
 struct ParsedDid {
 
     /// The complete DID URI.
-    var uri: String
+    let uri: String
 
+    /// The DID URI without the fragment part.
+    ///
+    /// Example: if the `uri` is `did:example:1234#keys-1`, `did:example:1234` would be the `uriWithoutFragment`
     var uriWithoutFragment: String {
         uri.components(separatedBy: "#")[0]
     }
@@ -20,12 +23,12 @@ struct ParsedDid {
     /// The method name specified in the DID URI.
     ///
     /// Example: if the `uri` is `did:example:123456`, "example" would be the method name
-    var methodName: String
+    let methodName: String
 
     /// The method specific identifier part of the DID URI.
     ///
     /// Example: if the `uri` is `did:example:123456`, "123456" would be the identifier
-    var methodSpecificId: String
+    let methodSpecificId: String
 
     /// The fragment part of the DID URI.
     ///

--- a/Sources/tbDEX/Protocol/CryptoUtils.swift
+++ b/Sources/tbDEX/Protocol/CryptoUtils.swift
@@ -1,0 +1,174 @@
+import CryptoKit
+import Foundation
+
+enum CryptoUtils {}
+
+// MARK: - Digest
+
+extension CryptoUtils {
+    
+    static func digest<D: Codable, M: Codable>(data: D, metadata: M) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .sortedKeys
+
+        let payload = DigestPayload(data: data, metadata: metadata)
+        let serializedPayload = try encoder.encode(payload)
+
+        let digest = SHA256.hash(data: serializedPayload)
+        return Data(digest)
+    }
+
+
+    private struct DigestPayload<D: Codable, M: Codable>: Codable {
+        let data: D
+        let metadata: M
+    }
+
+}
+
+// MARK: - Sign
+
+extension CryptoUtils {
+
+    enum SigningError: Error {
+        case assertionMethodNotFound
+        case publicKeyJwkNotFound
+    }
+
+    /// Signs the provided payload using the specified DID and key.
+    /// - Parameters:
+    ///   - did: DID to use for signing.
+    ///   - payload: The payload to sign.
+    ///   - assertionMethodId: The alias of the key to be used for signing.
+    /// - Throws: DOCUMENT THIS!!!
+    /// - Returns: The signed payload as a detached payload JWT (JSON Web Token).
+    static func sign<D>(did: Did, payload: D, assertionMethodId: String? = nil) async throws -> String
+    where D: DataProtocol{
+        let assertionMethod = try await getAssertionMethod(did: did, assertionMethodId: assertionMethodId)
+        guard let publicKeyJwk = assertionMethod.publicKeyJwk else {
+            // TODO: This seems wrong... What about trying `publicKeyMultibase`?
+            // This is just copied from `tbdex-kt` for now, but probably needs to be rethought
+            throw SigningError.publicKeyJwkNotFound
+        }
+
+        // TODO: again, this seems wrong. Don't we already have the public key?
+        let keyAlias = try did.keyManager.getDeterministicAlias(key: publicKeyJwk)
+        let publicKey = try did.keyManager.getPublicKey(keyAlias: keyAlias)
+        // TODO: remove force unwrap
+        let algorithm = publicKey!.algorithm!
+
+        let jwsHeader = JWS.Header(
+            algorithm: algorithm.jwsAlgorithm,
+            keyID: assertionMethod.id
+        )
+
+        let jwsObject = try JWS.Object(header: jwsHeader, payload: payload)
+        let signatureBytes = try did.keyManager.sign(keyAlias: keyAlias, payload: jwsObject.signingInput)
+
+        // TODO: `JSONEncoder().encode(jwsHeader).base64UrlEncodedString()` is computed twice, which is inefficient
+
+        let headerBase64 = try JSONEncoder().encode(jwsHeader).base64UrlEncodedString()
+        let signatureBase64 = signatureBytes.base64UrlEncodedString()
+        let signature = "\(headerBase64)..\(signatureBase64)"
+
+        return signature
+    }
+
+    private static func getAssertionMethod(did: Did, assertionMethodId: String?) async throws -> VerificationMethod {
+        let resolutionResult = await DidResolver.resolve(didUri: did.uri)
+        let assertionMethods = resolutionResult.didDocument?.assertionMethodDereferenced
+
+        guard let assertionMethod =
+            if let assertionMethodId {
+                assertionMethods?.first(where: { $0.id == assertionMethodId })
+            } else {
+                assertionMethods?.first
+            }
+        else {
+            throw SigningError.assertionMethodNotFound
+        }
+
+        return assertionMethod
+    }
+
+}
+
+
+// MARK: - Verify
+
+extension CryptoUtils {
+
+    struct VerifyError: Error {
+        let reason: String
+    }
+
+    // Verifies the integrity of a message or resource's signature.
+    static func verify<D: DataProtocol>(
+        didUri: String,
+        signature: String?,
+        detachedPayload: D? = nil
+    ) async throws -> Bool {
+        guard let signature else {
+            throw VerifyError(reason: "Signature not present")
+        }
+
+        let splitJWS = signature.split(separator: ".", omittingEmptySubsequences: false)
+
+        guard splitJWS.count == 3 else {
+            throw VerifyError(reason: "Excpected valid JWS with 3 parts, got \(splitJWS.count)")
+        }
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+
+        let jwsHeader = String(splitJWS[0])
+        let jwsSignature = String(splitJWS[2])
+        let jwsPayload: String
+
+        if let detachedPayload {
+            guard splitJWS[1].count == 0 else {
+                throw VerifyError(reason: "Expected valid JWS with detached payload")
+            }
+            jwsPayload = String(detachedPayload.base64UrlEncodedString())
+        } else {
+            jwsPayload = String(splitJWS[1])
+        }
+
+        guard let jwsHeader = try? JSONDecoder().decode(JWS.Header.self, from: jwsHeader.decodeBase64Url()),
+            let verificationMethodID =  jwsHeader.keyID
+        else {
+            throw VerifyError(reason: "")
+        }
+
+        let parsedDid = try ParsedDid(didUri: verificationMethodID)
+        let signingDidUri = parsedDid.uriWithoutFragment
+
+        guard signingDidUri == didUri else {
+            throw VerifyError(reason: "Was not signed by the expected DID - Expected:\(didUri) Actual:\(signingDidUri)")
+        }
+
+        let resolutionResult = await DidResolver.resolve(didUri: signingDidUri)
+        if let error = resolutionResult.didResolutionMetadata.error {
+            throw VerifyError(reason: "Failed to resolve DID \(signingDidUri): \(error)")
+        }
+
+        guard let assertionMethod =
+            resolutionResult.didDocument?.assertionMethodDereferenced?.first(
+                where: { $0.absoluteId == verificationMethodID }
+            )
+        else {
+            throw VerifyError(reason: "Assertion method not found")
+        }
+
+        let publicKeyJwk = assertionMethod.publicKeyJwk!
+
+        return try Crypto.verify(
+            publicKey: publicKeyJwk,
+            signature: try jwsSignature.decodeBase64Url(),
+            signedPayload: try jwsPayload.decodeBase64Url(),
+            algorithm: jwsHeader.algorithm.jwkAlgorithm
+        )
+    }
+
+}

--- a/Sources/tbDEX/Protocol/Models/Resource.swift
+++ b/Sources/tbDEX/Protocol/Models/Resource.swift
@@ -33,16 +33,16 @@ public struct Resource<D: ResourceData>: Codable {
         self.signature = nil
     }
 
-    func digest() throws -> Data {
+    private func digest() throws -> Data {
         try CryptoUtils.digest(data: data, metadata: metadata)
-    }
-
-    func verify() async throws {
-        _ = try await CryptoUtils.verify(didUri: metadata.from, signature: signature, detachedPayload: digest())
     }
 
     mutating func sign(did: Did, keyAlias: String? = nil) async throws {
         self.signature = try await CryptoUtils.sign(did: did, payload: digest(), assertionMethodId: keyAlias)
+    }
+
+    func verify() async throws {
+        _ = try await CryptoUtils.verify(didUri: metadata.from, signature: signature, detachedPayload: digest())
     }
 
 }

--- a/Sources/tbDEX/Protocol/Models/Resource.swift
+++ b/Sources/tbDEX/Protocol/Models/Resource.swift
@@ -14,7 +14,7 @@ public struct Resource<D: ResourceData>: Codable {
     public let data: D
 
     /// Signature that verifies the authenticity and integrity of the Resource
-    public let signature: String?
+    public private(set) var signature: String?
 
     /// Default Initializer
     init(
@@ -31,6 +31,18 @@ public struct Resource<D: ResourceData>: Codable {
         )
         self.data = data
         self.signature = nil
+    }
+
+    func digest() throws -> Data {
+        try CryptoUtils.digest(data: data, metadata: metadata)
+    }
+
+    func verify() async throws {
+        _ = try await CryptoUtils.verify(didUri: metadata.from, signature: signature, detachedPayload: digest())
+    }
+
+    mutating func sign(did: Did, keyAlias: String? = nil) async throws {
+        self.signature = try await CryptoUtils.sign(did: did, payload: digest(), assertionMethodId: keyAlias)
     }
 
 }

--- a/Sources/tbDEX/crypto/JWS.swift
+++ b/Sources/tbDEX/crypto/JWS.swift
@@ -57,7 +57,7 @@ struct JWS {
         let type: String?
 
         /// The "cty" (content type) Header Parameter is used by JWS applications to declare the media type
-        /// [[IANA.MediaTypes](https://datatracker.ietf.org/doc/html/rfc7515#ref-IANA.MediaTypes)] of the secured 
+        /// [[IANA.MediaTypes](https://datatracker.ietf.org/doc/html/rfc7515#ref-IANA.MediaTypes)] of the secured
         /// content (the payload).
         let contentType: String?
 
@@ -106,29 +106,6 @@ struct JWS {
             case critical = "crit"
         }
     }
-
-
-    struct Object {
-        let header: Header
-        let payload: any DataProtocol
-        let signingInput: Data
-        let signature: String?
-
-        init(header: Header, payload: any DataProtocol) throws {
-            self.header = header
-            self.payload = payload
-
-            let signingInputString =
-                "\(try JSONEncoder().encode(header).base64UrlEncodedString())"
-                + "."
-                + payload.base64UrlEncodedString()
-
-            // TODO: Remove this force unwrap
-            self.signingInput = signingInputString.data(using: .utf8)!
-            self.signature = nil
-        }
-    }
-
 }
 
 extension Jwk.Algorithm {
@@ -142,7 +119,6 @@ extension Jwk.Algorithm {
             return .es256k
         }
     }
-
 }
 
 extension JWS.Algorithm {
@@ -156,5 +132,4 @@ extension JWS.Algorithm {
             return .es256k
         }
     }
-
 }

--- a/Sources/tbDEX/crypto/JWS.swift
+++ b/Sources/tbDEX/crypto/JWS.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// [Specification Reference](https://datatracker.ietf.org/doc/html/rfc7515)]
+struct JWS {
+
+    // Supported JWS algorithms
+    enum Algorithm: String, Codable {
+        case eddsa
+        case es256k
+    }
+
+    /// JWS JOSE Header
+    ///
+    /// [Specification Reference](https://datatracker.ietf.org/doc/html/rfc7515#section-4)
+    struct Header: Codable {
+
+        /// The "alg" (algorithm) Header Parameter identifies the cryptographic algorithm used to secure the JWS.
+        let algorithm: Algorithm
+
+        /// The "jku" (JWK Set URL) Header Parameter is a URI [[RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)]
+        /// that refers to a resource for a set of JSON-encoded public keys, one of which corresponds to the key used
+        /// to digitally sign the JWS.
+        let jwkSetURL: String?
+
+        /// The "jwk" (JSON Web Key) Header Parameter is the public key that corresponds to the key used to digitally
+        /// sign the JWS.
+        let jwk: Jwk?
+
+        /// The "kid" (key ID) Header Parameter is a hint indicating which key was used to secure the JWS.
+        let keyID: String?
+
+        /// The "x5u" (X.509 URL) Header Parameter is a URI [[RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)]
+        /// that refers to a resource for the X.509 public key certificate or certificate chain
+        /// [RFC5280](https://datatracker.ietf.org/doc/html/rfc5280) corresponding to the key used to digitally sign
+        /// the JWS.
+        let x509URL: String?
+
+        /// The "x5c" (X.509 certificate chain) Header Parameter contains the X.509 public key certificate or
+        /// certificate chain [[RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)] corresponding to the key used
+        /// to digitally sign the JWS.
+        let x509CertificateChain: String?
+
+        /// The "x5t" (X.509 certificate SHA-1 thumbprint) Header Parameter is a base64url-encoded SHA-1 thumbprint
+        /// (a.k.a. digest) of the DER encoding of the X.509 certificate
+        /// [[RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)] corresponding to the key used to digitally sign
+        /// the JWS.
+        let x509CertificateSHA1Thumbprint: String?
+
+        /// The "x5t#S256" (X.509 certificate SHA-256 thumbprint) Header Parameter is a base64url-encoded SHA-256
+        /// thumbprint (a.k.a. digest) of the DER encoding of the X.509 certificate
+        /// [[RFC5280](https://datatracker.ietf.org/doc/html/rfc5280)] corresponding to the key used to digitally sign
+        /// the JWS.
+        let x509CertificateSHA256Thumbprint: String?
+
+        /// The "typ" (type) Header Parameter is used by JWS applications to declare the media type
+        /// [[IANA.MediaTypes](https://datatracker.ietf.org/doc/html/rfc7515#ref-IANA.MediaTypes)] of this complete JWS.
+        let type: String?
+
+        /// The "cty" (content type) Header Parameter is used by JWS applications to declare the media type
+        /// [[IANA.MediaTypes](https://datatracker.ietf.org/doc/html/rfc7515#ref-IANA.MediaTypes)] of the secured 
+        /// content (the payload).
+        let contentType: String?
+
+        /// The "crit" (critical) Header Parameter indicates that extensions to this specification
+        /// and/or [[JWA](https://datatracker.ietf.org/doc/html/rfc7515#ref-JWA)] are being used that
+        /// MUST be understood and processed.
+        let critical: [String]?
+
+        init(
+            algorithm: JWS.Algorithm,
+            jwkSetURL: String? = nil,
+            jwk: Jwk? = nil,
+            keyID: String? = nil,
+            x509URL: String? = nil,
+            x509CertificateChain: String? = nil,
+            x509CertificateSHA1Thumbprint: String? = nil,
+            x509CertificateSHA256Thumbprint: String? = nil,
+            type: String? = nil,
+            contentType: String? = nil,
+            critical: [String]? = nil
+        ) {
+            self.algorithm = algorithm
+            self.jwkSetURL = jwkSetURL
+            self.jwk = jwk
+            self.keyID = keyID
+            self.x509URL = x509URL
+            self.x509CertificateChain = x509CertificateChain
+            self.x509CertificateSHA1Thumbprint = x509CertificateSHA1Thumbprint
+            self.x509CertificateSHA256Thumbprint = x509CertificateSHA256Thumbprint
+            self.type = type
+            self.contentType = contentType
+            self.critical = critical
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case algorithm = "alg"
+            case jwkSetURL = "jku"
+            case jwk
+            case keyID = "kid"
+            case x509URL = "x5u"
+            case x509CertificateChain = "x5c"
+            case x509CertificateSHA1Thumbprint = "x5t"
+            case x509CertificateSHA256Thumbprint = "x5t#S256"
+            case type = "typ"
+            case contentType = "cty"
+            case critical = "crit"
+        }
+    }
+
+
+    struct Object {
+        let header: Header
+        let payload: any DataProtocol
+        let signingInput: Data
+        let signature: String?
+
+        init(header: Header, payload: any DataProtocol) throws {
+            self.header = header
+            self.payload = payload
+
+            let signingInputString =
+                "\(try JSONEncoder().encode(header).base64UrlEncodedString())"
+                + "."
+                + payload.base64UrlEncodedString()
+
+            // TODO: Remove this force unwrap
+            self.signingInput = signingInputString.data(using: .utf8)!
+            self.signature = nil
+        }
+    }
+
+}
+
+extension Jwk.Algorithm {
+
+    /// Converts a JWK algorithm to a JWS algorithm.
+    var jwsAlgorithm: JWS.Algorithm {
+        switch self {
+        case .eddsa:
+            return .eddsa
+        case .es256k:
+            return .es256k
+        }
+    }
+
+}
+
+extension JWS.Algorithm {
+
+    /// Converts a JWS algorithm to a JWK algorithm.
+    var jwkAlgorithm: Jwk.Algorithm {
+        switch self {
+        case .eddsa:
+            return .eddsa
+        case .es256k:
+            return .es256k
+        }
+    }
+
+}

--- a/TestUtilities/XCTest+Async.swift
+++ b/TestUtilities/XCTest+Async.swift
@@ -1,0 +1,39 @@
+import Foundation
+import XCTest
+
+extension XCTest {
+
+    /// Asserts that an asynchronous expression throws an error.
+    /// (Intended to function as a drop-in asynchronous version of `XCTAssertThrowsError`.)
+    ///
+    /// Example usage:
+    ///
+    ///     await XCTAssertThrowsErrorAsync(
+    ///         try await sut.function()
+    ///     ) { error in
+    ///         XCTAssertEqual(error as? MyError, MyError.specificError)
+    ///     }
+    ///
+    /// - Parameters:
+    ///   - expression: An asynchronous expression that can throw an error.
+    ///   - message: An optional description of a failure.
+    ///   - file: The file where the failure occurs.
+    ///     The default is the filename of the test case where you call this function.
+    ///   - line: The line number where the failure occurs.
+    ///     The default is the line number where you call this function.
+    ///   - errorHandler: An optional handler for errors that expression throws.
+    public func XCTAssertThrowsErrorAsync<T: Sendable>(
+        _ expression: @autoclosure () async throws -> T,
+        _ message: @autoclosure () -> String = "",
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ errorHandler: (_ error: Error) -> Void = { _ in }
+    ) async {
+        do {
+            _ = try await expression()
+            XCTFail(message(), file: file, line: line)
+        } catch {
+            errorHandler(error)
+        }
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
@@ -4,6 +4,27 @@ import XCTest
 
 final class OfferingTests: XCTestCase {
 
+    func test_init() {
+        let offering = Offering(
+            from: "pfi",
+            data: .init(
+                description: "test offering",
+                payoutUnitsPerPayinUnit: "1",
+                payinCurrency: .init(currencyCode: "AUD"),
+                payoutCurrency: .init(currencyCode: "BTC"),
+                payoutMethods: [],
+                requiredClaims: [:]
+            )
+        )
+
+        XCTAssertEqual(offering.metadata.id.prefix, "offering")
+        XCTAssertEqual(offering.metadata.from, "pfi")
+        XCTAssertEqual(offering.data.description, "test offering")
+        XCTAssertEqual(offering.data.payoutUnitsPerPayinUnit, "1")
+        XCTAssertEqual(offering.data.payinCurrency.currencyCode, "AUD")
+        XCTAssertEqual(offering.data.payoutCurrency.currencyCode, "BTC")
+    }
+
     func test_signAndVerifySuccess() async throws {
         do {
             let did = try DidJwk(keyManager: InMemoryKeyManager(), options: .init(algorithm: .eddsa, curve: .ed25519))
@@ -21,7 +42,9 @@ final class OfferingTests: XCTestCase {
 
     func test_verifyWithoutSigningFailure() async throws {
         let did = try DidJwk(keyManager: InMemoryKeyManager(), options: .init(algorithm: .eddsa, curve: .ed25519))
-        var offering = createOffering(from: did.uri)
+        let offering = createOffering(from: did.uri)
+
+        await XCTAssertThrowsErrorAsync(try await offering.verify())
     }
 
     private func createOffering(from: String) -> Offering {

--- a/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
@@ -5,17 +5,7 @@ import XCTest
 final class OfferingTests: XCTestCase {
 
     func test_init() {
-        let offering = Offering(
-            from: "pfi",
-            data: .init(
-                description: "test offering",
-                payoutUnitsPerPayinUnit: "1",
-                payinCurrency: .init(currencyCode: "AUD"),
-                payoutCurrency: .init(currencyCode: "BTC"),
-                payoutMethods: [],
-                requiredClaims: [:]
-            )
-        )
+        let offering = createOffering(from: "pfi")
 
         XCTAssertEqual(offering.metadata.id.prefix, "offering")
         XCTAssertEqual(offering.metadata.from, "pfi")

--- a/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
@@ -4,9 +4,29 @@ import XCTest
 
 final class OfferingTests: XCTestCase {
 
-    func test_init() {
-        let offering = Offering(
-            from: "pfi",
+    func test_signAndVerifySuccess() async throws {
+        do {
+            let did = try DidJwk(keyManager: InMemoryKeyManager(), options: .init(algorithm: .eddsa, curve: .ed25519))
+            var offering = createOffering(from: did.uri)
+
+            XCTAssertNil(offering.signature)
+            try await offering.sign(did: did)
+            XCTAssertNotNil(offering.signature)
+            try await offering.verify()
+        } catch {
+            print("Something went wrong: \(error)")
+            XCTFail()
+        }
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let did = try DidJwk(keyManager: InMemoryKeyManager(), options: .init(algorithm: .eddsa, curve: .ed25519))
+        var offering = createOffering(from: did.uri)
+    }
+
+    private func createOffering(from: String) -> Offering {
+        Offering(
+            from: from,
             data: .init(
                 description: "test offering",
                 payoutUnitsPerPayinUnit: "1",
@@ -16,13 +36,6 @@ final class OfferingTests: XCTestCase {
                 requiredClaims: [:]
             )
         )
-
-        XCTAssertEqual(offering.metadata.id.prefix, "offering")
-        XCTAssertEqual(offering.metadata.from, "pfi")
-        XCTAssertEqual(offering.data.description, "test offering")
-        XCTAssertEqual(offering.data.payoutUnitsPerPayinUnit, "1")
-        XCTAssertEqual(offering.data.payinCurrency.currencyCode, "AUD")
-        XCTAssertEqual(offering.data.payoutCurrency.currencyCode, "BTC")
     }
 
 }


### PR DESCRIPTION
Adds sign/verify functions to `Resource` & `Message`. Added some very sparse tests to this for now, will pull in test vectors next to ensure that these are working as intended for known given input.