### PR TITLE
Implement tbDEX protocol parsing test vectors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,16 @@ jobs:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
+
+    - name: Bootstrap
+      run: make bootstrap
+
     - uses: swift-actions/setup-swift@v1
       with:
         swift-version: "5.9"
+
     - name: Build
       run: swift build
+
     - name: Run tests
       run: swift test

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Tests/tbDEXTestVectors/tbdex-spec"]
+	path = Tests/tbDEXTestVectors/tbdex-spec
+	url = https://github.com/TBD54566975/tbdex

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,12 @@
+bootstrap:
+# Initialize submodules
+	git submodule update --init
+# Initialize sparse checkout in the `tbdex-spec` submodule
+	git -C Tests/tbDEXTestVectors/tbdex-spec config core.sparseCheckout true
+# Sparse checkout only the `hosted/test-vectors` directory from `tbdex-spec`
+	git -C Tests/tbDEXTestVectors/tbdex-spec sparse-checkout set hosted/test-vectors
+# Update submodules so they sparse checkout takes effect
+	git submodule update
+
 format:
 	swift format --in-place --recursive .

--- a/Package.swift
+++ b/Package.swift
@@ -17,6 +17,8 @@ let package = Package(
         .package(url: "https://github.com/Frizlab/swift-typeid.git", from: "0.3.0"),
         .package(url: "https://github.com/flight-school/anycodable.git", from: "0.6.7"),
         .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.1"),
+        .package(url: "https://github.com/allegro/swift-junit.git", from: "2.1.0"),
+        .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.1.2"),
     ],
     targets: [
         .target(
@@ -30,7 +32,18 @@ let package = Package(
         .testTarget(
             name: "tbDEXTests",
             dependencies: [
+                "tbDEX"
+            ]
+        ),
+        .testTarget(
+            name: "tbDEXTestVectors",
+            dependencies: [
                 "tbDEX",
+                .product(name: "SwiftTestReporter", package: "swift-junit"),
+                .product(name: "CustomDump", package: "swift-custom-dump"),
+            ],
+            resources: [
+                .copy("tbdex-spec/hosted/test-vectors")
             ]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -1,38 +1,14 @@
-# $PROJECT_NAME README
+# tbdex-swift
 
-Congrats, project leads! You got a new project to grow!
+WIP! 
 
-This stub is meant to help you form a strong community around your work. It's yours to adapt, and may 
-diverge from this initial structure. Just keep the files seeded in this repo, and the rest is yours to evolve! 
+# Prerequisites
 
-## Introduction
+## Cloning
 
-Orient users to the project here. This is a good place to start with an assumption
-that the user knows very little - so start with the Big Picture and show how this
-project fits into it. It may be good to reference/link the broader architecture in the
-`collaboration` repo or the developer site here.
+After cloning this repository, run:
+```
+make bootstrap
+```
 
-Then maybe a dive into what this project does.
-
-Diagrams and other visuals are helpful here. Perhaps code snippets showing usage.
-
-Project leads should complete, alongside this `README`:
-* [CODEOWNERS](./CODEOWNERS) - set project lead(s)
-* [CONTRIBUTING.md](./CONTRIBUTING.md) - Fill out how to: install prereqs, build, test, run, access CI, chat, discuss, file issues
-* [Bug-report.md](.github/ISSUE_TEMPLATE/bug-report.md) - Fill out `Assignees` add codeowners @names
-* [config.yml](.github/ISSUE_TEMPLATE/config.yml) - remove "(/add your discord channel..)" and replace the url with your Discord channel if applicable
-
-The other files in this template repo may be used as-is:
-* [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md)
-* [GOVERNANCE.md](./GOVERNANCE.md)
-* [LICENSE](./LICENSE)
-
-## Project Resources
-
-| Resource                                   | Description                                                                    |
-| ------------------------------------------ | ------------------------------------------------------------------------------ |
-| [CODEOWNERS](./CODEOWNERS)                 | Outlines the project lead(s)                                                   |
-| [CODE_OF_CONDUCT.md](./CODE_OF_CONDUCT.md) | Expected behavior for project contributors, promoting a welcoming environment |
-| [CONTRIBUTING.md](./CONTRIBUTING.md)       | Developer guide to build, test, run, access CI, chat, discuss, file issues     |
-| [GOVERNANCE.md](./GOVERNANCE.md)           | Project governance                                                             |
-| [LICENSE](./LICENSE)                       | Apache License, Version 2.0                                                    |
+This will configure the repository's submodules properly, and ensure you're all set to go!

--- a/Sources/tbDEX/Common/JSON/tbDEXDateFormatter.swift
+++ b/Sources/tbDEX/Common/JSON/tbDEXDateFormatter.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// A date formatter that can be used to encode and decode dates in the ISO8601 format,
+/// compatible with the larger tbDEX ecosystem.
+let tbDEXDateFormatter: ISO8601DateFormatter = {
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return dateFormatter
+}()

--- a/Sources/tbDEX/Common/JSON/tbDEXJSONDecoder.swift
+++ b/Sources/tbDEX/Common/JSON/tbDEXJSONDecoder.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public class tbDEXJSONDecoder: JSONDecoder {
+
+    public override init() {
+        super.init()
+
+        dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let dateString = try container.decode(String.self)
+
+            if let date = tbDEXDateFormatter.date(from: dateString) {
+                return date
+            } else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Invalid date: \(dateString)"
+                )
+            }
+        }
+    }
+}

--- a/Sources/tbDEX/Common/JSON/tbDEXJSONEncoder.swift
+++ b/Sources/tbDEX/Common/JSON/tbDEXJSONEncoder.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+public class tbDEXJSONEncoder: JSONEncoder {
+
+    public override init() {
+        super.init()
+
+        outputFormatting = .sortedKeys
+        dateEncodingStrategy = .custom { date, encoder in
+            var container = encoder.singleValueContainer()
+            try container.encode(tbDEXDateFormatter.string(from: date))
+        }
+    }
+}

--- a/Sources/tbDEX/Protocol/Models/AnyMessage.swift
+++ b/Sources/tbDEX/Protocol/Models/AnyMessage.swift
@@ -1,0 +1,79 @@
+import AnyCodable
+import Foundation
+
+/// Enumeration that can represent any `Message` type.
+///
+/// `AnyMessage` should be used in contexts when given a `Message`, but the exact type
+/// of the `Message` is unknown until runtime.
+///
+/// Example: When calling an endpoint that returns `Message`s, but it's impossible to know exactly
+/// what kind of `Message` it is until the JSON response is parsed.
+public enum AnyMessage {
+    case close(Close)
+    case order(Order)
+    case orderStatus(OrderStatus)
+    case quote(Quote)
+    case rfq(RFQ)
+
+    /// Parse a JSON string into an `AnyMessage` object, which can represent any message type.
+    /// - Parameter jsonString: A string containing a JSON representation of a `Message`
+    /// - Returns: An `AnyMessage` object, representing the parsed JSON string
+    public static func parse(_ jsonString: String) throws -> AnyMessage {
+        guard let data = jsonString.data(using: .utf8) else {
+            throw Error.invalidJSONString
+        }
+
+        return try tbDEXJSONDecoder().decode(AnyMessage.self, from: data)
+    }
+}
+
+// MARK: - Decodable
+
+extension AnyMessage: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        // Read the JSON payload into a dictionary representation
+        let messageJSONObject = try container.decode([String: AnyCodable].self)
+
+        // Ensure that a metadata object is present within the JSON payload
+        guard let metadataJSONObject = messageJSONObject["metadata"]?.value as? [String: Any] else {
+            throw DecodingError.valueNotFound(
+                AnyMessage.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "metadata not found"
+                )
+            )
+        }
+
+        // Decode the metadata into a strongly-typed `MessageMetadata` object
+        let metadataData = try JSONSerialization.data(withJSONObject: metadataJSONObject)
+        let metadata = try tbDEXJSONDecoder().decode(MessageMetadata.self, from: metadataData)
+
+        // Decode the message itself into it's strongly-typed representation, indicated by the `metadata.kind` field
+        switch metadata.kind {
+        case .close:
+            self = .close(try container.decode(Close.self))
+        case .order:
+            self = .order(try container.decode(Order.self))
+        case .orderStatus:
+            self = .orderStatus(try container.decode(OrderStatus.self))
+        case .quote:
+            self = .quote(try container.decode(Quote.self))
+        case .rfq:
+            self = .rfq(try container.decode(RFQ.self))
+        }
+    }
+}
+
+// MARK: - Errors
+
+extension AnyMessage {
+
+    public enum Error: Swift.Error {
+        /// The provided JSON string is invalid
+        case invalidJSONString
+    }
+}

--- a/Sources/tbDEX/Protocol/Models/AnyResource.swift
+++ b/Sources/tbDEX/Protocol/Models/AnyResource.swift
@@ -1,0 +1,64 @@
+import AnyCodable
+import Foundation
+
+/// Enumeration that can represent any `Resource` type.
+///
+/// `AnyResource` should be used in contexts when given a `Resource`, but the exact type
+/// of the `Resource` is unknown until runtime.
+///
+/// Example: When calling an endpoint that returns `Resource`s, but it's impossible to know exactly
+/// what kind of `Resource` it is until the JSON response is parsed.
+public enum AnyResource {
+    case offering(Offering)
+
+    public static func parse(_ jsonString: String) throws -> AnyResource {
+        guard let data = jsonString.data(using: .utf8) else {
+            throw Error.invalidJSONString
+        }
+
+        return try tbDEXJSONDecoder().decode(AnyResource.self, from: data)
+    }
+}
+
+// MARK: - Decodable
+
+extension AnyResource: Decodable {
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        // Read the JSON payload into a dictionary representation
+        let resourceJSONObject = try container.decode([String: AnyCodable].self)
+
+        // Ensure that a metadata object is present within the JSON payload
+        guard let metadataJSONObject = resourceJSONObject["metadata"]?.value as? [String: Any] else {
+            throw DecodingError.valueNotFound(
+                AnyResource.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "metadata not found"
+                )
+            )
+        }
+
+        // Decode the metadata into a strongly-typed `ResourceMetadata` object
+        let metadataData = try JSONSerialization.data(withJSONObject: metadataJSONObject)
+        let metadata = try tbDEXJSONDecoder().decode(ResourceMetadata.self, from: metadataData)
+
+        // Decode the resource itself into it's strongly-typed representation, indicated by the `metadata.kind` field
+        switch metadata.kind {
+        case .offering:
+            self = .offering(try container.decode(Offering.self))
+        }
+    }
+}
+
+// MARK: - Errors
+
+extension AnyResource {
+
+    enum Error: Swift.Error {
+        /// The provided JSON string is invalid
+        case invalidJSONString
+    }
+}

--- a/Sources/tbDEX/Protocol/Models/Messages/Close.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Close.swift
@@ -7,11 +7,10 @@ public typealias Close = Message<CloseData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#close)
 public struct CloseData: MessageData {
 
-    public var kind: Message<CloseData>.Kind {
-        .close
-    }
-
     /// An explanation of why the exchange is being closed/completed
     public let reason: String?
 
+    public func kind() -> MessageKind {
+        return .close
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/Order.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Order.swift
@@ -7,8 +7,8 @@ public typealias Order = Message<OrderData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#order)
 public struct OrderData: MessageData {
 
-    public var kind: Message<OrderData>.Kind {
-        .order
+    public func kind() -> MessageKind {
+        return .order
     }
 
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
@@ -7,11 +7,10 @@ public typealias OrderStatus = Message<OrderStatusData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#orderstatus)
 public struct OrderStatusData: MessageData {
 
-    public var kind: Message<OrderStatusData>.Kind {
-        .orderStatus
-    }
-
     /// Current status of Order that's being executed
     public let orderStatus: String
 
+    public func kind() -> MessageKind {
+        return .orderStatus
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
@@ -7,10 +7,6 @@ public typealias Quote = Message<QuoteData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#quote)
 public struct QuoteData: MessageData {
 
-    public var kind: Message<QuoteData>.Kind {
-        .quote
-    }
-
     /// When this quote expires.
     public let expiresAt: Date
 
@@ -23,12 +19,15 @@ public struct QuoteData: MessageData {
     /// Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link)
     public let paymentInstructions: PaymentInstructions?
 
+    public func kind() -> MessageKind {
+        return .quote
+    }
 }
 
 /// Details about a quoted amount
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#quotedetails)
-public struct QuoteDetails: Codable {
+public struct QuoteDetails: Codable, Equatable {
 
     /// ISO 3166 currency code string
     public let currencyCode: String
@@ -44,7 +43,7 @@ public struct QuoteDetails: Codable {
 /// Instructions about how one can pay or be paid by the PFI
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#paymentinstructions)
-public struct PaymentInstructions: Codable {
+public struct PaymentInstructions: Codable, Equatable {
 
     /// Link or Instruction describing how to pay the PFI.
     public let payin: PaymentInstruction?
@@ -57,7 +56,7 @@ public struct PaymentInstructions: Codable {
 /// Instruction about how to pay or be paid by the PFI
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#paymentinstruction)
-public struct PaymentInstruction: Codable {
+public struct PaymentInstruction: Codable, Equatable {
 
     /// Link to allow Alice to pay PFI, or be paid by the PFI
     public let link: String?

--- a/Sources/tbDEX/Protocol/Models/Messages/RFQ.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/RFQ.swift
@@ -8,10 +8,6 @@ public typealias RFQ = Message<RFQData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#rfq-request-for-quote)
 public struct RFQData: MessageData {
 
-    public var kind: Message<RFQData>.Kind {
-        .rfq
-    }
-
     /// Offering which Alice would like to get a quote for.
     public let offeringId: String
 
@@ -27,12 +23,16 @@ public struct RFQData: MessageData {
     /// Specify which payment method to receive payout currency.
     public let payoutMethod: SelectedPaymentMethod
 
+    public func kind() -> MessageKind {
+        return .rfq
+    }
+
 }
 
 /// Details about a selected payment method
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#selectedpaymentmethod)
-public struct SelectedPaymentMethod: Codable {
+public struct SelectedPaymentMethod: Codable, Equatable {
 
     /// Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)
     public let kind: String

--- a/Sources/tbDEX/Protocol/Models/Resource.swift
+++ b/Sources/tbDEX/Protocol/Models/Resource.swift
@@ -6,10 +6,10 @@ import Web5
 /// They are not part of the message exchange, i.e Alice cannot reply to a Resource.
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#resources)
-public struct Resource<D: ResourceData>: Codable {
+public struct Resource<D: ResourceData>: Codable, Equatable {
 
     /// An object containing fields about the Resource.
-    public let metadata: Metadata
+    public let metadata: ResourceMetadata
 
     /// The actual Resource content.
     public let data: D
@@ -23,9 +23,9 @@ public struct Resource<D: ResourceData>: Codable {
         data: D
     ) {
         let now = Date()
-        self.metadata = Metadata(
-            id: TypeID(prefix: data.kind.rawValue)!,
-            kind: data.kind,
+        self.metadata = ResourceMetadata(
+            id: TypeID(prefix: data.kind().rawValue)!,
+            kind: data.kind(),
             from: from,
             createdAt: now,
             updatedAt: now
@@ -48,60 +48,52 @@ public struct Resource<D: ResourceData>: Codable {
 
 }
 
-// MARK: - ResourceData
-
-/// The actual content of a `Resource`.
-public protocol ResourceData: Codable {
-
-    /// The kind of Resource the data represents
-    var kind: Resource<Self>.Kind { get }
-
+/// Enum containing the different types of Resources
+///
+/// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#resource-kinds)
+public enum ResourceKind: String, Codable {
+    case offering
 }
 
-// MARK: - Nested Types
+/// The actual content of a `Resource`.
+public protocol ResourceData: Codable, Equatable {
 
-extension Resource {
+    /// The kind of Resource the data represents
+    func kind() -> ResourceKind
+}
 
-    /// Enum containing the different types of Resources
-    ///
-    /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#resource-kinds)
-    public enum Kind: String, Codable {
-        case offering
-    }
+/// Structure containining fields about the Resource and is present in every tbDEX Resource.
+///
+/// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#metadata)
+public struct ResourceMetadata: Codable, Equatable {
 
-    /// Structure containining fields about the Resource and is present in every tbDEX Resource.
-    ///
-    /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#metadata)
-    public struct Metadata: Codable {
+    /// The resource's unique identifier
+    public let id: TypeID
 
-        /// The resource's unique identifier
-        public let id: TypeID
+    /// The data property's type. e.g. `offering`
+    public let kind: ResourceKind
 
-        /// The data property's type. e.g. `offering`
-        public let kind: Kind
+    /// The authors's DID URI
+    public let from: String
 
-        /// The authors's DID URI
-        public let from: String
+    /// The time at which the resource was created
+    public let createdAt: Date
 
-        /// The time at which the resource was created
-        public let createdAt: Date
+    /// The time at which the resource was last updated
+    public let updatedAt: Date?
 
-        /// The time at which the resource was last updated
-        public let updatedAt: Date?
-
-        /// Default Initializer
-        init(
-            id: TypeID,
-            kind: Kind,
-            from: String,
-            createdAt: Date,
-            updatedAt: Date? = nil
-        ) {
-            self.id = id
-            self.kind = kind
-            self.from = from
-            self.createdAt = createdAt
-            self.updatedAt = updatedAt
-        }
+    /// Default Initializer
+    init(
+        id: TypeID,
+        kind: ResourceKind,
+        from: String,
+        createdAt: Date,
+        updatedAt: Date? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.from = from
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
     }
 }

--- a/Sources/tbDEX/Protocol/Models/Resources/Offering.swift
+++ b/Sources/tbDEX/Protocol/Models/Resources/Offering.swift
@@ -9,10 +9,6 @@ public typealias Offering = Resource<OfferingData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#offering)
 public struct OfferingData: ResourceData {
 
-    public var kind: Resource<OfferingData>.Kind {
-        .offering
-    }
-
     /// Brief description of what is being offered.
     public let description: String
 
@@ -33,12 +29,15 @@ public struct OfferingData: ResourceData {
     /// Articulates the claim(s) required when submitting an RFQ for this offering.
     public let requiredClaims: AnyCodable
 
+    public func kind() -> ResourceKind {
+        return .offering
+    }
 }
 
 /// Details about currency within an Offering
 ///
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#currencydetails)
-public struct CurrencyDetails: Codable {
+public struct CurrencyDetails: Codable, Equatable {
 
     /// ISO 3166 currency code string
     public let currencyCode: String
@@ -65,7 +64,7 @@ public struct CurrencyDetails: Codable {
 /// Details about payment methods within an Offering
 ///
 /// [Specficication Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#paymentmethod)
-public struct PaymentMethod: Codable {
+public struct PaymentMethod: Codable, Equatable {
 
     /// Type of payment method (i.e. `DEBIT_CARD`, `BITCOIN_ADDRESS`, `SQUARE_PAY`)
     public let kind: String

--- a/Tests/tbDEXTestVectors/AAA_JUnitReportInitializer.swift
+++ b/Tests/tbDEXTestVectors/AAA_JUnitReportInitializer.swift
@@ -1,0 +1,18 @@
+import SwiftTestReporter
+import XCTest
+
+/// This test class must be executed first. The `AAA_` prefix helps ensure this,
+/// but it is not guaranteed. Make sure that this is alphabetically the first test
+/// class in the `tbDEXTestVectors` target!
+///
+/// This is necessary to allow `SwiftTestReporterInit` to create a `tests.xml`.
+/// See https://github.com/allegro/swift-junit/issues/12#issuecomment-725264315
+class AAA_JUnitReportInitializer: XCTestCase {
+    override class func setUp() {
+        _ = TestObserver()
+        super.setUp()
+    }
+
+    // No-op test function to be interpreted as a test case
+    func testInit() {}
+}

--- a/Tests/tbDEXTestVectors/TestVector.swift
+++ b/Tests/tbDEXTestVectors/TestVector.swift
@@ -1,0 +1,56 @@
+import Foundation
+import tbDEX
+
+/// Representation of a tbDEX test vector
+struct TestVector<Input: Codable, Output: Codable>: Codable {
+
+    /// A description of what the vector is tetings
+    let description: String
+
+    /// The input for the test vector, which can be of any `Codable` type.
+    let input: Input
+
+    /// The expected output for the test vector, which can be of any `Codable` type.
+    let output: Output
+
+    /// Indicates whether the test vector is expected to produce an error.
+    let error: Bool
+
+    /// Initialize a test vector from a file
+    /// - Parameters:
+    ///   - fileName: Name of the JSON file containing the test vector
+    ///   - subdirectory: Name of subdirectory that contains `fileName`. Used to disambiguate when there are multiple
+    ///   test vector files with the same name.
+    init(
+        fileName: String,
+        subdirectory: String? = nil
+    ) throws {
+        guard
+            let url = Bundle.module.url(
+                forResource: fileName,
+                withExtension: "json",
+                subdirectory: subdirectory
+            )
+        else {
+            throw Error.missingFile(fileName)
+        }
+
+        let data = try Data(contentsOf: url)
+        self = try tbDEXJSONDecoder().decode(Self<Input, Output>.self, from: data)
+    }
+}
+
+// MARK: - Errors
+
+extension TestVector {
+    enum Error: LocalizedError {
+        case missingFile(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .missingFile(fileName):
+                return "Missing file: \(fileName).json"
+            }
+        }
+    }
+}

--- a/Tests/tbDEXTestVectors/tbDEXTestVectorsProtocol.swift
+++ b/Tests/tbDEXTestVectors/tbDEXTestVectorsProtocol.swift
@@ -1,0 +1,97 @@
+import CustomDump
+import XCTest
+
+@testable import tbDEX
+
+final class tbDEXTestVectorsProtocol: XCTestCase {
+
+    let vectorSubdirectory = "test-vectors/protocol/vectors"
+
+    // MARK: - Resources
+
+    func test_parseOffering() throws {
+        let vector = try TestVector<String, Offering>(
+            fileName: "parse-offering",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedResource = try AnyResource.parse(vector.input)
+        guard case let .offering(parsedOffering) = parsedResource else {
+            return XCTFail("Parsed resource is not an Offering")
+        }
+
+        XCTAssertNoDifference(parsedOffering, vector.output)
+    }
+
+    // MARK: - Messages
+
+    func test_parseClose() throws {
+        let vector = try TestVector<String, Close>(
+            fileName: "parse-close",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .close(parsedClose) = parsedMessage else {
+            return XCTFail("Parsed message is not a Close")
+        }
+
+        XCTAssertNoDifference(parsedClose, vector.output)
+    }
+
+    func test_parseOrder() throws {
+        let vector = try TestVector<String, Order>(
+            fileName: "parse-order",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .order(parsedOrder) = parsedMessage else {
+            return XCTFail("Parsed message is not an Order")
+        }
+
+        XCTAssertNoDifference(parsedOrder, vector.output)
+    }
+
+    func test_parseOrderStatus() throws {
+        let vector = try TestVector<String, OrderStatus>(
+            fileName: "parse-orderstatus",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .orderStatus(parsedOrderStatus) = parsedMessage else {
+            return XCTFail("Parsed message is not an OrderStatus")
+        }
+
+        XCTAssertNoDifference(parsedOrderStatus, vector.output)
+    }
+
+    func test_parseQuote() throws {
+        let vector = try TestVector<String, Quote>(
+            fileName: "parse-quote",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .quote(parsedQuote) = parsedMessage else {
+            return XCTFail("Parsed message is not a Quote")
+        }
+
+        XCTAssertNoDifference(parsedQuote, vector.output)
+    }
+
+    func test_parseRfq() throws {
+        let vector = try TestVector<String, RFQ>(
+            fileName: "parse-rfq",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .rfq(parsedRFQ) = parsedMessage else {
+            return XCTFail("Parsed message is not an RFQ")
+        }
+
+        XCTAssertNoDifference(parsedRFQ, vector.output)
+    }
+}


### PR DESCRIPTION
* Pulls in the [test vectors](https://github.com/TBD54566975/tbdex) for tbDEX as a submodule. 
* Implements all current test vectors from that repository

An upcoming PR will integrate this repository with the [sdk-report-runner](https://github.com/TBD54566975/sdk-report-runner) repository.

--- 

`AnyMessage` and `AnyResource` are two new enums introduced with this PR to implement these test vectors. 

When parsing a Message/Resource from JSON, we need to do a few things:
1. Inspect the message's metadata
2. read the `metadata.kind` field
3. Parse the message into a strongly-typed `Message<D>` or `Resource<D>` object

Because we don't know the generic type of the message until the JSON is parsed (i.e. at runtime), we unfortunately cannot write a `Message.parse` function, as it would require the generic type to be known at compile time. To get around this limitation, `AnyMessage` and `AnyResource` can be used in any situation where you know that it _will be_ a message, we just know know concretely what type it is yet.