### PR TITLE
Update messages with latest spec changes, add tests for all of them

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/Frizlab/swift-typeid.git", from: "0.3.0"),
         .package(url: "https://github.com/flight-school/anycodable.git", from: "0.6.7"),
-        .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.3"),
+        .package(url: "https://github.com/TBD54566975/web5-swift", exact: "0.0.4"),
         .package(url: "https://github.com/allegro/swift-junit.git", from: "2.1.0"),
         .package(url: "https://github.com/pointfreeco/swift-custom-dump.git", from: "1.1.2"),
     ],

--- a/Sources/tbDEX/HttpClient/HttpClient.swift
+++ b/Sources/tbDEX/HttpClient/HttpClient.swift
@@ -65,7 +65,12 @@ public enum HttpClient {
     private static func getPFIServiceEndpoint(pfiDIDURI: String) async -> String? {
         let resolutionResult = await DIDResolver.resolve(didURI: pfiDIDURI)
         if let service = resolutionResult.didDocument?.service?.first(where: { $0.type == "PFI" }) {
-            return service.serviceEndpoint
+            switch service.serviceEndpoint {
+            case let .one(uri):
+                return uri
+            case let .many(uris):
+                return uris.first
+            }
         } else {
             return nil
         }

--- a/Sources/tbDEX/Protocol/Models/Message.swift
+++ b/Sources/tbDEX/Protocol/Models/Message.swift
@@ -45,16 +45,18 @@ public struct Message<D: MessageData>: Codable, Equatable {
         try CryptoUtils.digest(data: data, metadata: metadata)
     }
 
-    mutating func sign(did: BearerDID, keyAlias: String? = nil) throws {
+    public mutating func sign(did: BearerDID, keyAlias: String? = nil) throws {
         signature = try JWS.sign(
             did: did,
             payload: try digest(),
-            detached: true,
-            verificationMethodID: keyAlias
+            options: .init(
+                detached: true,
+                verificationMethodID: keyAlias
+            )
         )
     }
 
-    func verify() async throws -> Bool {
+    public func verify() async throws -> Bool {
         return try await JWS.verify(
             compactJWS: signature,
             detachedPayload: try digest(),
@@ -73,6 +75,8 @@ public enum MessageKind: String, Codable {
     case order
     case orderStatus = "orderstatus"
 }
+
+// MARK: - MessageData
 
 /// The actual content for a `Message`.
 public protocol MessageData: Codable, Equatable {

--- a/Sources/tbDEX/Protocol/Models/Messages/Close.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Close.swift
@@ -13,4 +13,11 @@ public struct CloseData: MessageData {
     public func kind() -> MessageKind {
         return .close
     }
+
+    /// Default Initializer
+    public init(
+        reason: String? = nil
+    ) {
+        self.reason = reason
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/Order.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Order.swift
@@ -11,4 +11,7 @@ public struct OrderData: MessageData {
         return .order
     }
 
+    /// Default Initializer
+    public init() {}
+
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
@@ -13,4 +13,11 @@ public struct OrderStatusData: MessageData {
     public func kind() -> MessageKind {
         return .orderStatus
     }
+
+    /// Default Initializer
+    public init(
+        orderStatus: String
+    ) {
+        self.orderStatus = orderStatus
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
@@ -16,11 +16,19 @@ public struct QuoteData: MessageData {
     /// The amount of payout currency that Alice will receive
     public let payout: QuoteDetails
 
-    /// Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link)
-    public let paymentInstructions: PaymentInstructions?
-
     public func kind() -> MessageKind {
         return .quote
+    }
+
+    /// Default Initializer
+    public init(
+        expiresAt: Date,
+        payin: QuoteDetails,
+        payout: QuoteDetails
+    ) {
+        self.expiresAt = expiresAt
+        self.payin = payin
+        self.payout = payout
     }
 }
 
@@ -38,19 +46,21 @@ public struct QuoteDetails: Codable, Equatable {
     /// The amount paid in fees
     public let fee: String?
 
-}
+    /// Object that describes how to pay the PFI, and how to get paid by the PFI (e.g. BTC address, payment link)
+    public let paymentInstruction: PaymentInstruction?
 
-/// Instructions about how one can pay or be paid by the PFI
-///
-/// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#paymentinstructions)
-public struct PaymentInstructions: Codable, Equatable {
-
-    /// Link or Instruction describing how to pay the PFI.
-    public let payin: PaymentInstruction?
-
-    /// Link or Instruction describing how to get paid by the PFI
-    public let payout: PaymentInstruction?
-
+    /// Default Initializer
+    public init(
+        currencyCode: String, 
+        amount: String,
+        fee: String? = nil,
+        paymentInstruction: PaymentInstruction? = nil
+    ) {
+        self.currencyCode = currencyCode
+        self.amount = amount
+        self.fee = fee
+        self.paymentInstruction = paymentInstruction
+    }
 }
 
 /// Instruction about how to pay or be paid by the PFI
@@ -64,4 +74,12 @@ public struct PaymentInstruction: Codable, Equatable {
     /// Instruction on how Alice can pay PFI, or how Alice can be paid by the PFI
     public let instruction: String?
 
+    /// Default Initializer
+    public init(
+        link: String? = nil,
+        instruction: String? = nil
+    ) {
+        self.link = link
+        self.instruction = instruction
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/RFQ.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/RFQ.swift
@@ -1,7 +1,30 @@
 import AnyCodable
 import Foundation
+import TypeID
 
 public typealias RFQ = Message<RFQData>
+
+extension RFQ {
+
+    public init(
+        to: String,
+        from: String,
+        data: RFQData
+    ) {
+        let id = TypeID(prefix: data.kind().rawValue)!
+        self.metadata = MessageMetadata(
+            id: id,
+            kind: data.kind(),
+            from: from,
+            to: to,
+            exchangeID: id.rawValue,
+            createdAt: Date()
+        )
+        self.data = data
+        self.private = nil
+    }
+
+}
 
 /// Data that makes up a RFQ Message.
 ///
@@ -27,6 +50,19 @@ public struct RFQData: MessageData {
         return .rfq
     }
 
+    public init(
+        offeringId: String,
+        payinAmount: String,
+        claims: [String],
+        payinMethod: SelectedPaymentMethod,
+        payoutMethod: SelectedPaymentMethod
+    ) {
+        self.offeringId = offeringId
+        self.payinAmount = payinAmount
+        self.claims = claims
+        self.payinMethod = payinMethod
+        self.payoutMethod = payoutMethod
+    }
 }
 
 /// Details about a selected payment method
@@ -39,4 +75,12 @@ public struct SelectedPaymentMethod: Codable, Equatable {
 
     /// An object containing the properties defined in an Offering's `requiredPaymentDetails` json schema
     public let paymentDetails: AnyCodable?
+
+    public init(
+        kind: String,
+        paymentDetails: AnyCodable? = nil
+    ) {
+        self.kind = kind
+        self.paymentDetails = paymentDetails
+    }
 }

--- a/Sources/tbDEX/Protocol/Models/Resource.swift
+++ b/Sources/tbDEX/Protocol/Models/Resource.swift
@@ -38,16 +38,18 @@ public struct Resource<D: ResourceData>: Codable, Equatable {
         try CryptoUtils.digest(data: data, metadata: metadata)
     }
 
-    mutating func sign(did: BearerDID, keyAlias: String? = nil) async throws {
+    public mutating func sign(did: BearerDID, keyAlias: String? = nil) throws {
         self.signature = try JWS.sign(
             did: did,
             payload: try digest(),
-            detached: true,
-            verificationMethodID: keyAlias
+            options: .init(
+                detached: true,
+                verificationMethodID: keyAlias
+            )
         )
     }
 
-    func verify() async throws -> Bool {
+    public func verify() async throws -> Bool {
         return try await JWS.verify(
             compactJWS: signature,
             detachedPayload: try digest(),

--- a/Sources/tbDEX/Protocol/Models/Resources/Offering.swift
+++ b/Sources/tbDEX/Protocol/Models/Resources/Offering.swift
@@ -21,8 +21,12 @@ public struct OfferingData: ResourceData {
     /// Details about the currency that the PFI is selling.
     public let payoutCurrency: CurrencyDetails
 
-    /// A list of payment methods the counterparty (Alice) can choose to send payment to the PFI from in order to
-    /// qualify for this offering.
+    /// A list of payment methods the counterparty (Alice) can choose to send payment
+    /// to the PFI from in order to qualify for this offering.
+    public let payinMethods: [PaymentMethod]
+
+    /// A list of payment methods the counterparty (Alice) can choose to receive payment
+    /// from the PFI in order to qualify for this offering.
     public let payoutMethods: [PaymentMethod]
 
     // TODO: amika - Update to PresentationDefinitionV2, requires third-party or custom implementation

--- a/Tests/tbDEXTests/Protocol/Models/Messages/CloseTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/CloseTests.swift
@@ -1,0 +1,52 @@
+import Web5
+import XCTest
+
+@testable import tbDEX
+
+final class CloseTests: XCTestCase {
+
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let pfi = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+
+    func test_init() {
+        let close = createClose(from: did.uri, to: pfi.uri)
+
+        XCTAssertEqual(close.metadata.id.prefix, "close")
+        XCTAssertEqual(close.metadata.from, did.uri)
+        XCTAssertEqual(close.metadata.to, pfi.uri)
+        XCTAssertEqual(close.metadata.exchangeID, "exchange_123")
+        XCTAssertEqual(close.data.reason, "test reason")
+    }
+
+    func test_signAndVerify() async throws {
+        let did = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        let pfi = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        var close = createClose(from: did.uri, to: pfi.uri)
+
+        XCTAssertNil(close.signature)
+        try close.sign(did: did)
+        XCTAssertNotNil(close.signature)
+        let isValid = try await close.verify()
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let close = createClose(from: did.uri, to: pfi.uri)
+
+        await XCTAssertThrowsErrorAsync(try await close.verify())
+    }
+
+    private func createClose(
+        from: String,
+        to: String
+    ) -> Close {
+        Close(
+            from: from,
+            to: to,
+            exchangeID: "exchange_123",
+            data: .init(
+                reason: "test reason"
+            )
+        )
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Messages/OrderStatusTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/OrderStatusTests.swift
@@ -1,0 +1,52 @@
+import Web5
+import XCTest
+
+@testable import tbDEX
+
+final class OrderStatusTests: XCTestCase {
+    
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let pfi = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+
+    func test_init() {
+        let orderStatus = createOrderStatus(from: did.uri, to: pfi.uri)
+
+        XCTAssertEqual(orderStatus.metadata.id.prefix, "orderstatus")
+        XCTAssertEqual(orderStatus.metadata.from, did.uri)
+        XCTAssertEqual(orderStatus.metadata.to, pfi.uri)
+        XCTAssertEqual(orderStatus.metadata.exchangeID, "exchange_123")
+        XCTAssertEqual(orderStatus.data.orderStatus, "test status")
+    }
+
+    func test_signAndVerify() async throws {
+        let did = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        let pfi = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        var orderStatus = createOrderStatus(from: did.uri, to: pfi.uri)
+
+        XCTAssertNil(orderStatus.signature)
+        try orderStatus.sign(did: did)
+        XCTAssertNotNil(orderStatus.signature)
+        let isValid = try await orderStatus.verify()
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let orderStatus = createOrderStatus(from: did.uri, to: pfi.uri)
+
+        await XCTAssertThrowsErrorAsync(try await orderStatus.verify())
+    }
+
+    private func createOrderStatus(
+        from: String,
+        to: String
+    ) -> OrderStatus {
+        OrderStatus(
+            from: from,
+            to: to,
+            exchangeID: "exchange_123",
+            data: .init(
+                orderStatus: "test status"
+            )
+        )
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Messages/OrderTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/OrderTests.swift
@@ -1,0 +1,49 @@
+import Web5
+import XCTest
+
+@testable import tbDEX
+
+final class OrderTests: XCTestCase {
+
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let pfi = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+
+    func test_init() {
+        let order = createOrder(from: did.uri, to: pfi.uri)
+
+        XCTAssertEqual(order.metadata.id.prefix, "order")
+        XCTAssertEqual(order.metadata.from, did.uri)
+        XCTAssertEqual(order.metadata.to, pfi.uri)
+        XCTAssertEqual(order.metadata.exchangeID, "exchange_123")
+    }
+
+    func test_signAndVerify() async throws {
+        let did = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        let pfi = try DIDJWK.create(keyManager: InMemoryKeyManager())
+        var order = createOrder(from: did.uri, to: pfi.uri)
+
+        XCTAssertNil(order.signature)
+        try order.sign(did: did)
+        XCTAssertNotNil(order.signature)
+        let isValid = try await order.verify()
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let order = createOrder(from: did.uri, to: pfi.uri)
+
+        await XCTAssertThrowsErrorAsync(try await order.verify())
+    }
+
+    private func createOrder(
+        from: String,
+        to: String
+    ) -> Order {
+        Order(
+            from: from,
+            to: to,
+            exchangeID: "exchange_123",
+            data: .init()
+        )
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Messages/QuoteTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/QuoteTests.swift
@@ -1,0 +1,76 @@
+import Web5
+import XCTest
+
+@testable import tbDEX
+
+final class QuoteTests: XCTestCase {
+
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let pfi = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+
+    func test_init() {
+        let quote = createQuote(from: did.uri, to: pfi.uri)
+
+        XCTAssertEqual(quote.metadata.id.prefix, "quote")
+        XCTAssertEqual(quote.metadata.from, did.uri)
+        XCTAssertEqual(quote.metadata.to, pfi.uri)
+        XCTAssertEqual(quote.metadata.exchangeID, "exchange_123")
+
+        XCTAssertEqual(quote.data.payin.currencyCode, "USD")
+        XCTAssertEqual(quote.data.payin.amount, "1.00")
+        XCTAssertNil(quote.data.payin.fee)
+        XCTAssertEqual(quote.data.payin.paymentInstruction?.link, "https://example.com")
+        XCTAssertEqual(quote.data.payin.paymentInstruction?.instruction, "test instruction")
+
+        XCTAssertEqual(quote.data.payout.currencyCode, "AUD")
+        XCTAssertEqual(quote.data.payout.amount, "2.00")
+        XCTAssertEqual(quote.data.payout.fee, "0.50")
+        XCTAssertNil(quote.data.payout.paymentInstruction)
+    }
+
+    func test_signAndVerify() async throws {
+        var quote = createQuote(from: did.uri, to: pfi.uri)
+
+        XCTAssertNil(quote.signature)
+        try quote.sign(did: did)
+        XCTAssertNotNil(quote.signature)
+        let isValid = try await quote.verify()
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let quote = createQuote(from: did.uri, to: pfi.uri)
+
+        await XCTAssertThrowsErrorAsync(try await quote.verify())
+    }
+
+    private func createQuote(
+        from: String,
+        to: String
+    ) -> Quote {
+        let now = Date()
+        let expiresAt = now.addingTimeInterval(60)
+
+        return Quote(
+            from: from,
+            to: to,
+            exchangeID: "exchange_123",
+            data: .init(
+                expiresAt: expiresAt,
+                payin: .init(
+                    currencyCode: "USD",
+                    amount: "1.00",
+                    paymentInstruction: .init(
+                        link: "https://example.com",
+                        instruction: "test instruction"
+                    )
+                ),
+                payout: .init(
+                    currencyCode: "AUD",
+                    amount: "2.00",
+                    fee: "0.50"
+                )
+            )
+        )
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Messages/RFQTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/RFQTests.swift
@@ -1,0 +1,61 @@
+import Web5
+import XCTest
+
+@testable import tbDEX
+
+final class RFQTests: XCTestCase {
+
+    let did = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+    let pfi = try! DIDJWK.create(keyManager: InMemoryKeyManager())
+
+    func test_init() {
+        let rfq = createRFQ(from: did.uri, to: pfi.uri)
+
+        XCTAssertEqual(rfq.metadata.id.prefix, "rfq")
+        XCTAssertEqual(rfq.metadata.from, did.uri)
+        XCTAssertEqual(rfq.metadata.to, pfi.uri)
+        XCTAssertEqual(rfq.metadata.exchangeID, rfq.metadata.id.rawValue)
+
+        XCTAssertEqual(rfq.data.payinAmount, "1.00")
+        XCTAssertEqual(rfq.data.claims, [])
+        XCTAssertEqual(rfq.data.payinMethod.kind, "DEBIT_CARD")
+        XCTAssertEqual(rfq.data.payoutMethod.kind, "BITCOIN_ADDRESS")
+    }
+
+    func test_signAndVerify() async throws {
+        var rfq = createRFQ(from: did.uri, to: pfi.uri)
+
+        XCTAssertNil(rfq.signature)
+        try rfq.sign(did: did)
+        XCTAssertNotNil(rfq.signature)
+        let isValid = try await rfq.verify()
+        XCTAssertTrue(isValid)
+    }
+
+    func test_verifyWithoutSigningFailure() async throws {
+        let rfq = createRFQ(from: did.uri, to: pfi.uri)
+
+        await XCTAssertThrowsErrorAsync(try await rfq.verify())
+    }
+
+    private func createRFQ(
+        from: String,
+        to: String
+    ) -> RFQ {
+        RFQ(
+            to: to,
+            from: from,
+            data: .init(
+                offeringId: "offering_123",
+                payinAmount: "1.00",
+                claims: [],
+                payinMethod: .init(
+                    kind: "DEBIT_CARD"
+                ),
+                payoutMethod: .init(
+                    kind: "BITCOIN_ADDRESS"
+                )
+            )
+        )
+    }
+}

--- a/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Resources/OfferingTests.swift
@@ -21,7 +21,7 @@ final class OfferingTests: XCTestCase {
         var offering = createOffering(from: did.uri)
 
         XCTAssertNil(offering.signature)
-        try await offering.sign(did: did)
+        try offering.sign(did: did)
         XCTAssertNotNil(offering.signature)
         let isValid = try await offering.verify()
         XCTAssertTrue(isValid)
@@ -42,6 +42,7 @@ final class OfferingTests: XCTestCase {
                 payoutUnitsPerPayinUnit: "1",
                 payinCurrency: .init(currencyCode: "AUD"),
                 payoutCurrency: .init(currencyCode: "BTC"),
+                payinMethods: [],
                 payoutMethods: [],
                 requiredClaims: [:]
             )


### PR DESCRIPTION
Updates all `Message` types with the latest changes documented in the [spec](https://github.com/TBD54566975/tbdex/blob/main/specs/protocol/README.md).

Added unit tests for each Message type to ensure each one can be created, signed, and verified.