### PR TITLE
feat: update tbDEX test vectors

### DIFF
--- a/Sources/tbDEX/Common/JSON/tbDEXDateFormatter.swift
+++ b/Sources/tbDEX/Common/JSON/tbDEXDateFormatter.swift
@@ -7,3 +7,12 @@ let tbDEXDateFormatter: ISO8601DateFormatter = {
     dateFormatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     return dateFormatter
 }()
+
+
+/// A date formatter that can be used to decode dates in the ISO8601 format
+/// without fractional seconds.
+let tbDEXFallbackDateFormatter: ISO8601DateFormatter = {
+    let dateFormatter = ISO8601DateFormatter()
+    dateFormatter.formatOptions = [.withInternetDateTime]
+    return dateFormatter
+}()

--- a/Sources/tbDEX/Common/JSON/tbDEXJSONDecoder.swift
+++ b/Sources/tbDEX/Common/JSON/tbDEXJSONDecoder.swift
@@ -8,15 +8,15 @@ public class tbDEXJSONDecoder: JSONDecoder {
         dateDecodingStrategy = .custom { decoder in
             let container = try decoder.singleValueContainer()
             let dateString = try container.decode(String.self)
-
-            if let date = tbDEXDateFormatter.date(from: dateString) {
+            
+            if let date = tbDEXDateFormatter.date(from: dateString) ?? tbDEXFallbackDateFormatter.date(from: dateString) {
                 return date
-            } else {
-                throw DecodingError.dataCorruptedError(
-                    in: container,
-                    debugDescription: "Invalid date: \(dateString)"
-                )
             }
+
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid date: \(dateString)"
+            )
         }
     }
 }

--- a/Sources/tbDEX/Protocol/DevTools.swift
+++ b/Sources/tbDEX/Protocol/DevTools.swift
@@ -131,15 +131,17 @@ enum DevTools {
         
         let quoteData = data ?? QuoteData(
             expiresAt: expiresAt,
+            payoutUnitsPerPayinUnit: "1.0",
             payin: .init(
                 currencyCode: "USD",
-                amount: "1.00"
-               
+                subtotal: "1.00",
+                total: "1.00"
             ),
             payout: .init(
                 currencyCode: "AUD",
-                amount: "2.00",
-                fee: "0.50"
+                subtotal: "2.00",
+                fee: "0.50",
+                total: "2.50"
             )
         )
         
@@ -250,7 +252,7 @@ enum DevTools {
         protocol: String? = nil
     ) -> OrderStatus {
         let orderStatusData = data ?? OrderStatusData(
-            orderStatus: "test status"
+            status: Status.payinInitiated
         )
         
         if let `protocol` = `protocol` {

--- a/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/OrderStatus.swift
@@ -8,7 +8,10 @@ public typealias OrderStatus = Message<OrderStatusData>
 public struct OrderStatusData: MessageData {
 
     /// Current status of Order that's being executed
-    public let orderStatus: String
+    public let status: Status
+
+    /// Additional details about the status
+    public let details: String?
 
     /// Returns the MessageKind of orderstatus
     public func kind() -> MessageKind {
@@ -17,8 +20,29 @@ public struct OrderStatusData: MessageData {
 
     /// Default Initializer
     public init(
-        orderStatus: String
+        status: Status,
+        details: String? = nil
     ) {
-        self.orderStatus = orderStatus
+        self.status = status
+        self.details = details
     }
+}
+
+/// Enum representing the various statuses in the OrderStatus Message.
+///
+/// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#status)
+public enum Status: String, Codable {
+    case payinPending = "PAYIN_PENDING"
+    case payinInitiated = "PAYIN_INITIATED"
+    case payinSettled = "PAYIN_SETTLED"
+    case payinFailed = "PAYIN_FAILED"
+    case payinExpired = "PAYIN_EXPIRED"
+    case payoutPending = "PAYOUT_PENDING"
+    case payoutInitiated = "PAYOUT_INITIATED"
+    case payoutSettled = "PAYOUT_SETTLED"
+    case payoutFailed = "PAYOUT_FAILED"
+    case refundPending = "REFUND_PENDING"
+    case refundInitiated = "REFUND_INITIATED"
+    case refundFailed = "REFUND_FAILED"
+    case refundSettled = "REFUND_SETTLED"
 }

--- a/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
+++ b/Sources/tbDEX/Protocol/Models/Messages/Quote.swift
@@ -7,8 +7,11 @@ public typealias Quote = Message<QuoteData>
 /// [Specification Reference](https://github.com/TBD54566975/tbdex/tree/main/specs/protocol#quote)
 public struct QuoteData: MessageData {
 
-    /// When this quote expires.
+    /// When this quote expires
     public let expiresAt: Date
+    
+    /// The exchange rate to convert from payin currency to payout currency
+    public let payoutUnitsPerPayinUnit: String
 
     /// The amount of payin currency that the PFI will receive
     public let payin: QuoteDetails
@@ -24,10 +27,12 @@ public struct QuoteData: MessageData {
     /// Default Initializer
     public init(
         expiresAt: Date,
+        payoutUnitsPerPayinUnit: String,
         payin: QuoteDetails,
         payout: QuoteDetails
     ) {
         self.expiresAt = expiresAt
+        self.payoutUnitsPerPayinUnit = payoutUnitsPerPayinUnit
         self.payin = payin
         self.payout = payout
     }
@@ -41,20 +46,27 @@ public struct QuoteDetails: Codable, Equatable {
     /// ISO 3166 currency code string
     public let currencyCode: String
 
-    /// The amount of currency expressed in the smallest respective unit
-    public let amount: String
-
+    /// The amount of currency paid for the exchange, excluding fees
+    public let subtotal: String
+    
     /// The amount paid in fees
     public let fee: String?
+    
+    /// The total amount of currency to be paid in or paid out
+    public let total: String
+
+
 
     /// Default Initializer
     public init(
         currencyCode: String, 
-        amount: String,
-        fee: String? = nil
+        subtotal: String,
+        fee: String? = nil,
+        total: String
     ) {
         self.currencyCode = currencyCode
-        self.amount = amount
+        self.subtotal = subtotal
         self.fee = fee
+        self.total = total
     }
 }

--- a/Tests/tbDEXTestVectors/tbDEXTestVectorsProtocol.swift
+++ b/Tests/tbDEXTestVectors/tbDEXTestVectorsProtocol.swift
@@ -52,6 +52,20 @@ final class tbDEXTestVectorsProtocol: XCTestCase {
 
         XCTAssertNoDifference(parsedClose, vector.output)
     }
+    
+    func test_parse_cancel() throws {
+        let vector = try TestVector<String, Cancel>(
+            fileName: "parse-cancel",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .cancel(parsedCancel) = parsedMessage else {
+            return XCTFail("Parsed message is not a Cancel")
+        }
+
+        XCTAssertNoDifference(parsedCancel, vector.output)
+    }
 
     func test_parse_order() throws {
         let vector = try TestVector<String, Order>(
@@ -65,6 +79,20 @@ final class tbDEXTestVectorsProtocol: XCTestCase {
         }
 
         XCTAssertNoDifference(parsedOrder, vector.output)
+    }
+    
+    func test_parse_orderinstructions() throws {
+        let vector = try TestVector<String, OrderInstructions>(
+            fileName: "parse-orderinstructions",
+            subdirectory: vectorSubdirectory
+        )
+
+        let parsedMessage = try AnyMessage.parse(vector.input)
+        guard case let .orderInstructions(parsedOrderInstructions) = parsedMessage else {
+            return XCTFail("Parsed message is not an OrderInstructions")
+        }
+
+        XCTAssertNoDifference(parsedOrderInstructions, vector.output)
     }
 
     func test_parse_orderstatus() throws {

--- a/Tests/tbDEXTests/Protocol/Models/Messages/OrderStatusTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/OrderStatusTests.swift
@@ -15,7 +15,7 @@ final class OrderStatusTests: XCTestCase {
         XCTAssertEqual(orderStatus.metadata.from, pfi.uri)
         XCTAssertEqual(orderStatus.metadata.to, did.uri)
         XCTAssertEqual(orderStatus.metadata.exchangeID, "exchange_123")
-        XCTAssertEqual(orderStatus.data.orderStatus, "test status")
+        XCTAssertEqual(orderStatus.data.status, Status.payinInitiated)
     }
 
     func test_verifySuccess() async throws {

--- a/Tests/tbDEXTests/Protocol/Models/Messages/QuoteTests.swift
+++ b/Tests/tbDEXTests/Protocol/Models/Messages/QuoteTests.swift
@@ -17,12 +17,14 @@ final class QuoteTests: XCTestCase {
         XCTAssertEqual(quote.metadata.exchangeID, "exchange_123")
 
         XCTAssertEqual(quote.data.payin.currencyCode, "USD")
-        XCTAssertEqual(quote.data.payin.amount, "1.00")
+        XCTAssertEqual(quote.data.payin.total, "1.00")
         XCTAssertNil(quote.data.payin.fee)
 
         XCTAssertEqual(quote.data.payout.currencyCode, "AUD")
-        XCTAssertEqual(quote.data.payout.amount, "2.00")
+        XCTAssertEqual(quote.data.payout.subtotal, "2.00")
         XCTAssertEqual(quote.data.payout.fee, "0.50")
+        XCTAssertEqual(quote.data.payout.total, "2.50")
+
     }
 
     func test_verifySuccess() async throws {


### PR DESCRIPTION
- this pr updates the tbDEX test vectors and introduces the following:
  - updates `Quote` message to include `payoutUnitsPerPayinUnit` alongwith `subtotal` and `total`
  - updates `OrderStatus` message to include `details` and the new `Status` enum 
  - updates `tbDEXJSONDecoder` to handle test vectors that don't have fractional seconds in the `createdAt` field