### PR TITLE
feat: update `tbDEXHttpClient` to use `submitCancel()`

### DIFF
--- a/Sources/tbDEX/HttpClient/tbDEXHttpClient.swift
+++ b/Sources/tbDEX/HttpClient/tbDEXHttpClient.swift
@@ -103,15 +103,15 @@ public enum tbDEXHttpClient {
         try await sendMessage(message: order, messageEndpoint: "/exchanges/\(exchangeID)")
     }
     
-    /// Sends the Close message to the PFI
+    /// Sends the Cancel message to the PFI
     /// - Parameters:
-    ///   - order: The Close message that will be sent to the PFI
+    ///   - cancel: The Cancel message that will be sent to the PFI
     /// - Throws: if message verification fails
     /// - Throws: if recipient DID resolution fails
     /// - Throws: if recipient DID does not have a PFI service entry
-    public static func submitClose(close: Close) async throws {
-        let exchangeID = close.metadata.exchangeID
-        try await sendMessage(message: close, messageEndpoint: "/exchanges/\(exchangeID)")
+    public static func submitCancel(cancel: Cancel) async throws {
+        let exchangeID = cancel.metadata.exchangeID
+        try await sendMessage(message: cancel, messageEndpoint: "/exchanges/\(exchangeID)")
     }
 
     /// Sends a message to a PFI

--- a/Tests/tbDEXTests/HttpClient/tbDEXHttpClientTests.swift
+++ b/Tests/tbDEXTests/HttpClient/tbDEXHttpClientTests.swift
@@ -277,10 +277,10 @@ final class tbDEXHttpClientTests: XCTestCase {
         }
     }
     
-    func test_submitCloseWhenSuccess() async throws {
-        var close = DevTools.createClose(from: did.uri, to: pfiDid)
+    func test_submitCancelWhenSuccess() async throws {
+        var cancel = DevTools.createCancel(from: did.uri, to: pfiDid)
         
-        try close.sign(did: did)
+        try cancel.sign(did: did)
         
         Mocker.mode = .optin
         Mock(
@@ -288,14 +288,14 @@ final class tbDEXHttpClientTests: XCTestCase {
             contentType: .json,
             statusCode: 200,
             data: [
-                .put: try tbDEXJSONEncoder().encode(close)
+                .put: try tbDEXJSONEncoder().encode(cancel)
             ]
         ).register()
         
         do {
-            try await tbDEXHttpClient.submitClose(close: close)
+            try await tbDEXHttpClient.submitCancel(cancel: cancel)
         } catch {
-            XCTFail("Error on submit order: \(error)")
+            XCTFail("Error on submit cancel: \(error)")
         }
     }
     


### PR DESCRIPTION
this pr replaces the `submitClose()` method with `submitCancel()` since the `Close` message is reserved for PFI use while the `Cancel` message is reserved for clients